### PR TITLE
Add MaskShortReads and OverrideCycles to Settings section

### DIFF
--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -54,7 +54,11 @@ _READS = {
 }
 
 _SETTINGS = {
-    'ReverseComplement': '0'
+    'ReverseComplement': '0',
+
+    # these are needed ever since we moved from bcl2fastq -> bclconvert
+    'MaskShortReads': '1',
+    'OverrideCycles': 'Y151;I8N2;I8N2;Y151'
 }
 
 _HEADER = {
@@ -425,6 +429,11 @@ def _add_metadata_to_sheet(metadata, sheet):
     if metadata['Assay'] == _AMPLICON:
         del sheet.Header['Investigator Name']
         del sheet.Header['Experiment Name']
+
+        # these are only relevant for metagenomics because they are used in
+        # bclconvert
+        del sheet.Settings['MaskShortReads']
+        del sheet.Settings['OverrideCycles']
 
     return sheet
 

--- a/metapool/tests/data/bad-project-name-sample-sheet.csv
+++ b/metapool/tests/data/bad-project-name-sample-sheet.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/good-sample-sheet-but-with-comments.csv
+++ b/metapool/tests/data/good-sample-sheet-but-with-comments.csv
@@ -18,6 +18,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/good-sample-sheet-with-comments-and-new-lines.csv
+++ b/metapool/tests/data/good-sample-sheet-with-comments-and-new-lines.csv
@@ -18,6 +18,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/good-sample-sheet-with-new-lines.csv
+++ b/metapool/tests/data/good-sample-sheet-with-new-lines.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/good-sample-sheet.csv
+++ b/metapool/tests/data/good-sample-sheet.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/no-project-name-sample-sheet.csv
+++ b/metapool/tests/data/no-project-name-sample-sheet.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Not_A_Sample_Project,Well_description

--- a/metapool/tests/data/ok-sample-sheet.csv
+++ b/metapool/tests/data/ok-sample-sheet.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/data/scrubbable-sample-sheet.csv
+++ b/metapool/tests/data/scrubbable-sample-sheet.csv
@@ -15,6 +15,8 @@ Chemistry,Default,,,,,,,,,
 ,,,,,,,,,,
 [Settings],,,,,,,,,,
 ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
 ,,,,,,,,,,
 [Data],,,,,,,,,,
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -750,6 +750,39 @@ class SampleSheetWorkflow(BaseTests):
 
             self.assertEqual(dict(sample), dict(exp))
 
+    def test_add_metadata_to_sheet_all_defaults_amplicon(self):
+        sheet = KLSampleSheet()
+
+        self.metadata['Assay'] = 'TruSeq HT'
+        exp_bfx = pd.DataFrame(self.metadata['Bioinformatics'])
+        exp_contact = pd.DataFrame(self.metadata['Contact'])
+
+        obs = _add_metadata_to_sheet(self.metadata, sheet)
+
+        self.assertEqual(obs.Reads, [151, 151])
+
+        settings = {
+            'ReverseComplement': '0',
+        }
+        self.assertEqual(obs.Settings, settings)
+
+        pd.testing.assert_frame_equal(obs.Bioinformatics, exp_bfx)
+        pd.testing.assert_frame_equal(obs.Contact, exp_contact)
+
+        header = {
+            'IEMFileVersion': '4',
+            'Date': datetime.today().strftime('%Y-%m-%d'),
+            'Workflow': 'GenerateFASTQ',
+            'Application': 'FASTQ Only',
+            'Assay': 'TruSeq HT',
+            'Description': '',
+            'Chemistry': 'Default',
+        }
+
+        self.assertEqual(obs.Header, header)
+
+        self.assertEqual(len(obs.samples), 0)
+
     def test_add_metadata_to_sheet_most_defaults(self):
         sheet = KLSampleSheet()
 
@@ -760,7 +793,13 @@ class SampleSheetWorkflow(BaseTests):
         obs = _add_metadata_to_sheet(self.metadata, sheet)
 
         self.assertEqual(obs.Reads, [151, 151])
-        self.assertEqual(obs.Settings, {'ReverseComplement': '0'})
+
+        settings = {
+            'ReverseComplement': '0',
+            'MaskShortReads': '1',
+            'OverrideCycles': 'Y151;I8N2;I8N2;Y151'
+        }
+        self.assertEqual(obs.Settings, settings)
 
         pd.testing.assert_frame_equal(obs.Bioinformatics, exp_bfx)
         pd.testing.assert_frame_equal(obs.Contact, exp_contact)


### PR DESCRIPTION
These two values are needed now that we've moved away from bcl2fastq to bclconvert. These changes have been documented in the sample sheet specification and should make its way out in the 2021.09 revision.