### PR TITLE
Adding metatranscriptomics as a valid entry for 'Assay'.

### DIFF
--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -45,9 +45,22 @@ _KL_METAGENOMICS_REMAPPER = {
     'Project Name': 'Sample_Project',
 }
 
+_KL_METATRANSCRIPTOMICS_REMAPPER = {
+    'sample sheet Sample_ID': 'Sample_ID',
+    'Sample': 'Sample_Name',
+    'Project Plate': 'Sample_Plate',
+    'Well': 'Sample_Well',
+    'i7 name': 'I7_Index_ID',
+    'i7 sequence': 'index',
+    'i5 name': 'I5_Index_ID',
+    'i5 sequence': 'index2',
+    'Project Name': 'Sample_Project',
+}
+
 _AMPLICON = 'TruSeq HT'
 _METAGENOMICS = 'Metagenomics'
-_ASSAYS = {_AMPLICON, _METAGENOMICS}
+_METATRANSCRIPTOMICS = 'Metatranscriptomics'
+_ASSAYS = {_AMPLICON, _METAGENOMICS, _METATRANSCRIPTOMICS}
 
 _READS = {
     'Read1': 151,
@@ -458,6 +471,8 @@ def _remap_table(table, assay):
         remapper = _KL_AMPLICON_REMAPPER
     elif assay == _METAGENOMICS:
         remapper = _KL_METAGENOMICS_REMAPPER
+    elif assay == _METATRANSCRIPTOMICS:
+        remapper = _KL_METATRANSCRIPTOMICS_REMAPPER
 
     # make a copy because we are going to modify the data
     out = table[remapper.keys()].copy()
@@ -481,7 +496,7 @@ def _add_data_to_sheet(table, sheet, sequencer, lanes, assay):
     table = _remap_table(table, assay)
 
     # for amplicon we don't have reverse barcodes
-    if assay == _METAGENOMICS:
+    if assay != _AMPLICON:
         table['index2'] = sequencer_i5_index(sequencer, table['index2'])
 
         sheet.Bioinformatics['BarcodesAreRC'] = str(

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -492,10 +492,10 @@ class KLSampleSheetTests(BaseTests):
         self.assertEqual(obs, exp)
 
     def test_validate_missing_assay(self):
-        self.metadata['Assay'] = 'Metatranscriptomics'
+        self.metadata['Assay'] = 'NewAssayType'
 
         obs = _validate_sample_sheet_metadata(self.metadata)
-        exp = [ErrorMessage('Metatranscriptomics is not a supported Assay')]
+        exp = [ErrorMessage('NewAssayType is not a supported Assay')]
         self.assertEqual(obs, exp)
 
     def test_validate_missing_bioinformatics_data(self):

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -741,6 +741,48 @@ class SampleSheetWorkflow(BaseTests):
         self.assertEqual(len(obs), 3)
         pd.testing.assert_frame_equal(obs, exp, check_like=True)
 
+    def test_remap_table_metatranscriptomics(self):
+        data = [
+            ['33-A1', 'A', 1, True, 'A1', 0, 0, 'AACGCACACTCGTCTT',
+             'iTru5_19_A', 'AACGCACA', 'A1', 'iTru5_plate', 'iTru7_109_01',
+             'CTCGTCTT', 'A22', 'iTru7_plate', '33-A1'],
+            ['820072905-2', 'C', 1, False, 'C1', 1, 1, 'ATGCCTAGCGAACTGT',
+             'iTru5_19_B', 'ATGCCTAG', 'B1', 'iTru5_plate', 'iTru7_109_02',
+             'CGAACTGT', 'B22', 'iTru7_plate', '820072905-2'],
+            ['820029517-3', 'E', 1, False, 'E1', 2, 2, 'CATACGGACATTCGGT',
+             'iTru5_19_C', 'CATACGGA', 'C1', 'iTru5_plate', 'iTru7_109_03',
+             'CATTCGGT', 'C22', 'iTru7_plate', '820029517-3']
+        ]
+        columns = ['Sample', 'Row', 'Col', 'Blank', 'Well', 'index',
+                   'index combo', 'index combo seq', 'i5 name', 'i5 sequence',
+                   'i5 well', 'i5 plate', 'i7 name', 'i7 sequence', 'i7 well',
+                   'i7 plate', 'sample sheet Sample_ID']
+        self.table = pd.DataFrame(data=data, columns=columns)
+        self.table['Project Name'] = 'Tst_project_1234'
+        self.table['Project Plate'] = 'The_plate'
+
+        columns = ['Sample_ID', 'Sample_Name', 'Sample_Plate', 'Sample_Well',
+                   'I7_Index_ID', 'index', 'I5_Index_ID', 'index2',
+                   'Sample_Project', 'Well_description']
+        data = [
+            ['33-A1', '33-A1', 'The_plate', 'A1', 'iTru7_109_01',
+             'CTCGTCTT', 'iTru5_19_A', 'AACGCACA', 'Tst_project_1234',
+             '33-A1'],
+            ['820072905-2', '820072905-2', 'The_plate', 'C1', 'iTru7_109_02',
+             'CGAACTGT', 'iTru5_19_B', 'ATGCCTAG', 'Tst_project_1234',
+             '820072905-2'],
+            ['820029517-3', '820029517-3', 'The_plate', 'E1', 'iTru7_109_03',
+             'CATTCGGT', 'iTru5_19_C', 'CATACGGA', 'Tst_project_1234',
+             '820029517-3'],
+        ]
+
+        exp = pd.DataFrame(columns=columns, data=data)
+
+        obs = _remap_table(self.table, 'Metatranscriptomics')
+
+        self.assertEqual(len(obs), 3)
+        pd.testing.assert_frame_equal(obs, exp, check_like=True)
+
     def test_add_data_to_sheet(self):
 
         # for amplicon we expect the following three columns to not be there


### PR DESCRIPTION
@wasade @antgonza @RodolfoSalido As far as I know, column name remapping for metagenomics and metatranscriptomics should be the same and both have reverse barcodes, right?