### PR TITLE
Added option to return prep-file output paths w/study id.

### DIFF
--- a/metapool/__init__.py
+++ b/metapool/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from .prep import (preparations_for_run, parse_prep, generate_qiita_prep_file,
-                   preparations_for_run_mapping_file)
+                   preparations_for_run_mapping_file, remove_qiita_id)
 from .sample_sheet import (sample_sheet_to_dataframe, KLSampleSheet,
                            validate_and_scrub_sample_sheet, make_sample_sheet,
                            quiet_validate_and_scrub_sample_sheet)
@@ -20,7 +20,7 @@ __all__ = ['preparations_for_run', 'parse_prep', 'generate_qiita_prep_file',
            'assign_emp_index', 'IGMManifest', 'run_counts',
            'requires_dilution', 'dilute_gDNA', 'autopool', 'find_threshold',
            'extract_stats_metadata', 'sum_lanes',
-           'preparations_for_run_mapping_file']
+           'preparations_for_run_mapping_file', 'remove_qiita_id']
 
 from . import _version
 

--- a/metapool/scripts/seqpro.py
+++ b/metapool/scripts/seqpro.py
@@ -82,7 +82,7 @@ def format_preparation_files(run_dir, sample_sheet, output_dir, pipeline,
             # assume qiita_id is extractable and is an integer, given that
             # we have already passed error-checking.
             qiita_id = project.replace(project_name + '_', '')
-            print("%s (%s)" % (abspath(fp), qiita_id))
+            print("%s\t%s" % (qiita_id, abspath(fp)))
 
 
 if __name__ == '__main__':

--- a/metapool/scripts/seqpro.py
+++ b/metapool/scripts/seqpro.py
@@ -3,9 +3,11 @@
 import click
 import os
 import re
+from os.path import abspath
 
 from metapool import (preparations_for_run, KLSampleSheet,
-                      sample_sheet_to_dataframe, run_counts)
+                      sample_sheet_to_dataframe, run_counts,
+                      remove_qiita_id)
 
 
 @click.command()
@@ -17,7 +19,10 @@ from metapool import (preparations_for_run, KLSampleSheet,
 @click.option('--pipeline', help='Which pipeline generated the data',
               show_default=True, default='fastp-and-minimap2',
               type=click.Choice(['atropos-and-bowtie2', 'fastp-and-minimap2']))
-def format_preparation_files(run_dir, sample_sheet, output_dir, pipeline):
+@click.option('--verbose', help='list prep-file output paths, study_ids',
+              is_flag=True)
+def format_preparation_files(run_dir, sample_sheet, output_dir, pipeline,
+                             verbose):
     """Generate the preparation files for the projects in a run
 
     RUN_DIR: should be the directory where the results of running bcl2fastq are
@@ -53,7 +58,7 @@ def format_preparation_files(run_dir, sample_sheet, output_dir, pipeline):
     os.makedirs(output_dir, exist_ok=True)
 
     for (run, project, lane), df in preps.items():
-        filename = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
+        fp = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
 
         if pipeline == 'fastp-and-minimap2':
             # stats are indexed by sample name and lane, lane is the first
@@ -70,7 +75,14 @@ def format_preparation_files(run_dir, sample_sheet, output_dir, pipeline):
         # the values for sample_project.
         df['center_project_name'] = df['sample_project']
 
-        df.to_csv(filename, sep='\t', index=False)
+        df.to_csv(fp, sep='\t', index=False)
+
+        if verbose:
+            project_name = remove_qiita_id(project)
+            # assume qiita_id is extractable and is an integer, given that
+            # we have already passed error-checking.
+            qiita_id = project.replace(project_name + '_', '')
+            print("%s (%s)" % (abspath(fp), qiita_id))
 
 
 if __name__ == '__main__':

--- a/metapool/scripts/seqpro_mf.py
+++ b/metapool/scripts/seqpro_mf.py
@@ -3,8 +3,9 @@
 import click
 import os
 import pandas as pd
+from os.path import abspath
 
-from metapool import preparations_for_run_mapping_file
+from metapool import preparations_for_run_mapping_file, remove_qiita_id
 
 
 @click.command()
@@ -13,7 +14,9 @@ from metapool import preparations_for_run_mapping_file
 @click.argument('mapping_file', type=click.Path(exists=True, dir_okay=False,
                                                 file_okay=True))
 @click.argument('output_dir', type=click.Path(writable=True))
-def format_preparation_files_mf(run_dir, mapping_file, output_dir):
+@click.option('--verbose', help='list prep-file output paths, study_ids',
+              is_flag=True)
+def format_preparation_files_mf(run_dir, mapping_file, output_dir, verbose):
     """Generate the preparation files for the projects in a run
 
     RUN_DIR: should be the directory where the results of running bcl2fastq are
@@ -37,9 +40,9 @@ def format_preparation_files_mf(run_dir, mapping_file, output_dir):
     os.makedirs(output_dir, exist_ok=True)
 
     for (run, project, lane), df in preps.items():
-        filename = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
+        fp = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
 
-        df.to_csv(filename,
+        df.to_csv(fp,
                   sep='\t',
                   index=False,
                   # finalize column order
@@ -56,6 +59,13 @@ def format_preparation_files_mf(run_dir, mapping_file, output_dir):
                            'target_gene', 'target_subfragment',
                            'tm1000_8_tool', 'tm300_8_tool', 'tm50_8_tool',
                            'water_lot', 'well_description', 'well_id'])
+
+        if verbose:
+            project_name = remove_qiita_id(project)
+            # assume qiita_id is extractable and is an integer, given that
+            # we have already passed error-checking.
+            qiita_id = project.replace(project_name + '_', '')
+            print("%s (%s)" % (abspath(fp), qiita_id))
 
 
 if __name__ == '__main__':

--- a/metapool/scripts/seqpro_mf.py
+++ b/metapool/scripts/seqpro_mf.py
@@ -65,7 +65,7 @@ def format_preparation_files_mf(run_dir, mapping_file, output_dir, verbose):
             # assume qiita_id is extractable and is an integer, given that
             # we have already passed error-checking.
             qiita_id = project.replace(project_name + '_', '')
-            print("%s (%s)" % (abspath(fp), qiita_id))
+            print("%s\t%s" % (qiita_id, abspath(fp)))
 
 
 if __name__ == '__main__':

--- a/metapool/scripts/tests/test_seqpro.py
+++ b/metapool/scripts/tests/test_seqpro.py
@@ -95,21 +95,25 @@ class SeqproTests(unittest.TestCase):
         stdout, stderr = proc.communicate()
         return_code = proc.returncode
 
-        # truncate full-path output to be file-system agnostic.
-        tmp = stdout.split('\n')
-        tmp = [re.sub('^.*metagenomics_pooling_notebook/',
-                      'metagenomics_pooling_notebook/', x) for x in tmp]
+        tmp = []
+
+        # remove trailing whitespace before splitting each line into pairs.
+        for line in stdout.strip().split('\n'):
+            qiita_id, file_path = line.split('\t')
+            # truncate full-path output to be file-system agnostic.
+            file_path = re.sub('^.*metagenomics_pooling_notebook/',
+                               'metagenomics_pooling_notebook/', file_path)
+            tmp.append(f'{qiita_id}\t{file_path}')
+
         stdout = '\n'.join(tmp)
 
-        self.assertEqual(('metagenomics_pooling_notebook/metapool/tests/VFTEST'
-                          '/200318_A00953_0082_AH5TWYDSXY.Project_1111.1.tsv '
-                          '(1111)\nmetagenomics_pooling_notebook/metapool/'
-                          'tests/VFTEST/200318_A00953_0082_AH5TWYDSXY.Project'
-                          '_1111.3.tsv (1111)\nmetagenomics_pooling_notebook/'
-                          'metapool/tests/VFTEST/200318_A00953_0082_AH5TWYDSXY'
-                          '.Trojecp_666.3.tsv (666)\n'),
-                         stdout)
-
+        self.assertEqual(('1111\tmetagenomics_pooling_notebook/metapool/tests'
+                          '/VFTEST/200318_A00953_0082_AH5TWYDSXY.Project_1111'
+                          '.1.tsv\n1111\tmetagenomics_pooling_notebook/metapo'
+                          'ol/tests/VFTEST/200318_A00953_0082_AH5TWYDSXY.Proj'
+                          'ect_1111.3.tsv\n666\tmetagenomics_pooling_notebook'
+                          '/metapool/tests/VFTEST/200318_A00953_0082_AH5TWYDS'
+                          'XY.Trojecp_666.3.tsv'), stdout)
         self.assertEqual('', stderr)
         self.assertEqual(0, return_code)
 

--- a/metapool/scripts/tests/test_seqpro.py
+++ b/metapool/scripts/tests/test_seqpro.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 from metapool.scripts.seqpro import format_preparation_files
 from shutil import copy, copytree, rmtree
 from os.path import join
+from subprocess import Popen, PIPE
 
 
 class SeqproTests(unittest.TestCase):
@@ -12,7 +13,8 @@ class SeqproTests(unittest.TestCase):
         # important to use abspath because we use CliRunner.isolated_filesystem
         tests_dir = os.path.abspath(os.path.dirname(__file__))
         tests_dir = os.path.dirname(os.path.dirname(tests_dir))
-        data_dir = os.path.join(tests_dir, 'tests', 'data')
+        self.test_dir = os.path.join(tests_dir, 'tests')
+        data_dir = os.path.join(self.test_dir, 'data')
 
         self.run = os.path.join(data_dir, 'runs',
                                 '191103_D32611_0365_G00DHB5YXX')
@@ -72,6 +74,37 @@ class SeqproTests(unittest.TestCase):
                 with open(prep) as f:
                     self.assertEqual(len(f.read().split('\n')), exp_lines,
                                      'Assertion error in %s' % prep)
+
+    def test_verbose_flag(self):
+        self.maxDiff = None
+        sample_dir = 'metapool/tests/data/runs/200318_A00953_0082_AH5TWYDSXY'
+        output_dir = os.path.join(self.test_dir, 'VFTEST')
+
+        cmd = ['seqpro', '--verbose',
+               sample_dir,
+               join(sample_dir, 'sample-sheet.csv'),
+               output_dir]
+
+        proc = Popen(' '.join(cmd), universal_newlines=True, shell=True,
+                     stdout=PIPE, stderr=PIPE)
+
+        stdout, stderr = proc.communicate()
+        return_code = proc.returncode
+        self.assertEqual(('/Users/ccowart/Development/Pipeline/metagenomics_'
+                          'pooling_notebook/metapool/tests/VFTEST/200318_A00'
+                          '953_0082_AH5TWYDSXY.Project_1111.1.tsv (1111)\n/U'
+                          'sers/ccowart/Development/Pipeline/metagenomics_po'
+                          'oling_notebook/metapool/tests/VFTEST/200318_A0095'
+                          '3_0082_AH5TWYDSXY.Project_1111.3.tsv (1111)\n/Use'
+                          'rs/ccowart/Development/Pipeline/metagenomics_pool'
+                          'ing_notebook/metapool/tests/VFTEST/200318_A00953_'
+                          '0082_AH5TWYDSXY.Trojecp_666.3.tsv (666)\n'),
+                         stdout)
+
+        self.assertEqual('', stderr)
+        self.assertEqual(0, return_code)
+
+        rmtree(output_dir)
 
 
 class SeqproBCLConvertTests(unittest.TestCase):

--- a/metapool/scripts/tests/test_seqpro_mf.py
+++ b/metapool/scripts/tests/test_seqpro_mf.py
@@ -18,6 +18,7 @@ class SeqproAmpliconTests(unittest.TestCase):
         tests_dir = os.path.dirname(os.path.dirname(tests_dir))
         self.test_dir = os.path.join(tests_dir, 'tests')
         self.data_dir = os.path.join(self.test_dir, 'data')
+        self.vf_test_dir = os.path.join(self.test_dir, 'VFTEST')
 
         self.fastp_run = os.path.join(self.data_dir, 'runs',
                                       '230207_M05314_0346_000000000-KVMGL')
@@ -36,6 +37,9 @@ class SeqproAmpliconTests(unittest.TestCase):
 
     def tearDown(self):
         rmtree(self.temp_copy)
+        # this output-path isn't created for all tests. ignore error if it
+        # does not exist.
+        rmtree(self.vf_test_dir, ignore_errors=True)
 
     def test_run(self):
         runner = CliRunner()
@@ -90,12 +94,11 @@ class SeqproAmpliconTests(unittest.TestCase):
         self.maxDiff = None
         sample_dir = ('metapool/tests/data/runs/230207_M05314_0346_000000000'
                       '-KVMGL')
-        output_dir = os.path.join(self.test_dir, 'VFTEST2')
 
         cmd = ['seqpro_mf', '--verbose',
                sample_dir,
                join(sample_dir, 'sample_mapping_file.tsv'),
-               output_dir]
+               self.vf_test_dir]
 
         proc = Popen(' '.join(cmd), universal_newlines=True, shell=True,
                      stdout=PIPE, stderr=PIPE)
@@ -103,16 +106,17 @@ class SeqproAmpliconTests(unittest.TestCase):
         stdout, stderr = proc.communicate()
         return_code = proc.returncode
 
-        self.assertEqual(('/Users/ccowart/Development/Pipeline/metagenomics_'
-                          'pooling_notebook/metapool/tests/VFTEST2/230207_M0'
-                          '5314_0346_000000000-KVMGL.ABTX_20230208_ABTX_1105'
-                          '2.1.tsv (11052)\n'),
+        # truncate full-path output to be file-system agnostic.
+        stdout = re.sub('^.*metagenomics_pooling_notebook/',
+                        'metagenomics_pooling_notebook/', stdout)
+
+        self.assertEqual(('metagenomics_pooling_notebook/metapool/tests/'
+                          'VFTEST/230207_M05314_0346_000000000-KVMGL.ABTX_'
+                          '20230208_ABTX_11052.1.tsv (11052)\n'),
                          stdout)
 
         self.assertEqual('', stderr)
         self.assertEqual(0, return_code)
-
-        rmtree(output_dir)
 
 
 if __name__ == '__main__':

--- a/metapool/scripts/tests/test_seqpro_mf.py
+++ b/metapool/scripts/tests/test_seqpro_mf.py
@@ -106,15 +106,21 @@ class SeqproAmpliconTests(unittest.TestCase):
         stdout, stderr = proc.communicate()
         return_code = proc.returncode
 
-        # truncate full-path output to be file-system agnostic.
-        stdout = re.sub('^.*metagenomics_pooling_notebook/',
-                        'metagenomics_pooling_notebook/', stdout)
+        tmp = []
 
-        self.assertEqual(('metagenomics_pooling_notebook/metapool/tests/'
-                          'VFTEST/230207_M05314_0346_000000000-KVMGL.ABTX_'
-                          '20230208_ABTX_11052.1.tsv (11052)\n'),
-                         stdout)
+        # remove trailing whitespace before splitting each line into pairs.
+        for line in stdout.strip().split('\n'):
+            qiita_id, file_path = line.split('\t')
+            # truncate full-path output to be file-system agnostic.
+            file_path = re.sub('^.*metagenomics_pooling_notebook/',
+                               'metagenomics_pooling_notebook/', file_path)
+            tmp.append(f'{qiita_id}\t{file_path}')
 
+        stdout = '\n'.join(tmp)
+
+        self.assertEqual(('11052\tmetagenomics_pooling_notebook/metapool/tests'
+                          '/VFTEST/230207_M05314_0346_000000000-KVMGL.ABTX_202'
+                          '30208_ABTX_11052.1.tsv'), stdout)
         self.assertEqual('', stderr)
         self.assertEqual(0, return_code)
 


### PR DESCRIPTION
Output is one line per file, w/study id in parentheses. (Easily readable by human or machine).