### PR TITLE
Fix raw_reads count extraction.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,12 +66,8 @@ jobs:
         run: |
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          # wget https://github.com/biocore/qiita/archive/dev.zip
-          wget https://github.com/charles-cowart/qiita/archive/refs/heads/cert_fix_dev.zip
-          # unzip dev.zip
-          unzip cert_fix_dev.zip
-          # rename to make downstream commands work
-          mv qiita-cert_fix_dev qiita-dev
+          wget https://github.com/biocore/qiita/archive/dev.zip
+          unzip dev.zip
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}
@@ -94,8 +90,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate qiita
-          # export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
-          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/rootCA.crt
+          export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
 
@@ -130,9 +125,8 @@ jobs:
           pip install -e ".[all]"
 
           # create local Qiita connection
-          # export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
-          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/rootCA.crt
-          echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
+          export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
+          echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_ROOTCA_CERT}" > qiita.oauth2.cfg.local
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,8 @@ jobs:
         run: |
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          wget https://github.com/biocore/qiita/archive/dev.zip
+          # wget https://github.com/biocore/qiita/archive/dev.zip
+          wget https://github.com/charles-cowart/qiita/archive/cert_fix_dev.zip
           unzip dev.zip
 
           # pull out the port so we can modify the configuration file easily
@@ -90,7 +91,8 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate qiita
-          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
+          # export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
+          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/rootCA.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,9 @@ jobs:
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
 
+          PEM_PATH=`find /home/runner/miniconda3/envs/metapool | grep cacert.pem$ | grep 'site-packages/certifi'`
+          cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
+          mv ./appended_cacert.pem $PEM_PATH
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,15 +128,9 @@ jobs:
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
 
-          PEM_PATH=`which python`
-          echo "PEM_PATH: $PEM_PATH"
-
-          #PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$`
-          #cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
-          #cat ./appended_cacert.pem
-          #echo "MOVING"
-          #mv ./appended_cacert.pem $PEM_PATH
-          #cat $PEM_PATH
+          cat /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem $QIITA_SERVER_CERT > ./appended_cacert.pem
+          mv ./appended_cacert.pem /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem
+          cat /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,13 +127,16 @@ jobs:
           # create local Qiita connection
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
-          PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$`
+
+          PEM_PATH=`which python`
           echo "PEM_PATH: $PEM_PATH"
-          cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
-          cat ./appended_cacert.pem
-          echo "MOVING"
-          mv ./appended_cacert.pem $PEM_PATH
-          cat $PEM_PATH
+
+          #PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$`
+          #cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
+          #cat ./appended_cacert.pem
+          #echo "MOVING"
+          #mv ./appended_cacert.pem $PEM_PATH
+          #cat $PEM_PATH
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
           # create local Qiita connection
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
-          PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$
+          PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$`
           echo "PEM_PATH: $PEM_PATH"
           cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
           cat ./appended_cacert.pem

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,9 +128,14 @@ jobs:
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
 
-          PEM_PATH=`find /home/runner/miniconda3/envs/metapool | grep cacert.pem$ | grep 'site-packages/certifi'`
+          /Users/ccowart/miniconda3/envs/donald/bin/python
+          PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$
+          echo "PEM_PATH: $PEM_PATH"
           cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem
+          cat ./appended_cacert.pem
+          echo "MOVING"
           mv ./appended_cacert.pem $PEM_PATH
+          cat $PEM_PATH
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,8 @@ jobs:
           wget https://github.com/charles-cowart/qiita/archive/refs/heads/cert_fix_dev.zip
           # unzip dev.zip
           unzip cert_fix_dev.zip
+          # rename to make downstream commands work
+          mv qiita-cert_fix_dev qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,8 +67,9 @@ jobs:
           # we need to download qiita directly so we have "easy" access to
           # all config files
           # wget https://github.com/biocore/qiita/archive/dev.zip
-          wget https://github.com/charles-cowart/qiita/archive/cert_fix_dev.zip
-          unzip dev.zip
+          wget https://github.com/charles-cowart/qiita/archive/refs/heads/cert_fix_dev.zip
+          # unzip dev.zip
+          unzip cert_fix_dev.zip
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,12 +130,9 @@ jobs:
           pip install -e ".[all]"
 
           # create local Qiita connection
-          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
+          # export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
+          export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/rootCA.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
-
-          cat /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem $QIITA_SERVER_CERT > ./appended_cacert.pem
-          mv ./appended_cacert.pem /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem
-          cat /usr/share/miniconda/envs/metapool/lib/python3.9/site-packages/certifi/cacert.pem
       - name: Run tests and measure coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,8 +127,6 @@ jobs:
           # create local Qiita connection
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           echo -e "[qiita-oauth2]\nURL=https://localhost:8383\nCLIENT_ID=yKDgajoKn5xlOA8tpo48Rq8mWJkH9z4LBCx2SvqWYLIryaan2u\nCLIENT_SECRET=9xhU5rvzq8dHCEI5sSN95jesUULrZi6pT6Wuc71fDbFbsrnWarcSq56TJLN4kP4hH\nSERVER_CERT=${QIITA_SERVER_CERT}" > qiita.oauth2.cfg.local
-
-          /Users/ccowart/miniconda3/envs/donald/bin/python
           PEM_PATH=`find /home/runner | grep 'site-packages/certifi' | grep metapool | grep cacert.pem$
           echo "PEM_PATH: $PEM_PATH"
           cat $PEM_PATH $QIITA_SERVER_CERT > ./appended_cacert.pem

--- a/metapool/count.py
+++ b/metapool/count.py
@@ -195,12 +195,16 @@ def _bclconvert_counts(path):
     df = pd.read_csv(path)
     # subselect only the columns we're concerned with
     df = df[["SampleID", "Lane", "# Reads"]]
+
+    # double # Reads to represent forward and reverse reads.
+    df['raw_reads'] = df['# Reads'] * 2
+    df.drop('# Reads', axis=1, inplace=True)
+
     # filter out rows that reference an 'Undetermined' fastq.gz file
     # and create our own copy to return to the user
     df = df.loc[df['SampleID'] != 'Undetermined'].copy()
     # rename columns to standard values for metapool
-    df.rename(columns={'SampleID': 'Sample_ID', '# Reads': 'raw_reads'},
-              inplace=True)
+    df.rename(columns={'SampleID': 'Sample_ID'}, inplace=True)
     # create indexes on these columns
     df['Lane'] = df['Lane'].astype(str)
     df.set_index(['Sample_ID', 'Lane'], inplace=True, verify_integrity=True)

--- a/metapool/count.py
+++ b/metapool/count.py
@@ -183,9 +183,10 @@ def _bcl2fastq_counts(path):
         out.append(table)
 
     out = pd.concat(out)
-    out.rename(columns={'SampleId': 'Sample_ID', 'NumberReads': 'raw_reads'},
+    out.rename(columns={'SampleId': 'Sample_ID',
+                        'NumberReads': 'raw_reads_r1r2'},
                inplace=True)
-    out = out[['Sample_ID', 'Lane', 'raw_reads']]
+    out = out[['Sample_ID', 'Lane', 'raw_reads_r1r2']]
     out.set_index(['Sample_ID', 'Lane'], inplace=True, verify_integrity=True)
     return out
 
@@ -197,7 +198,7 @@ def _bclconvert_counts(path):
     df = df[["SampleID", "Lane", "# Reads"]]
 
     # double # Reads to represent forward and reverse reads.
-    df['raw_reads'] = df['# Reads'] * 2
+    df['raw_reads_r1r2'] = df['# Reads'] * 2
     df.drop('# Reads', axis=1, inplace=True)
 
     # filter out rows that reference an 'Undetermined' fastq.gz file
@@ -214,7 +215,7 @@ def _bclconvert_counts(path):
 
 def fastp_counts(run_dir, metadata):
     return _parsefier(run_dir, metadata, 'json', '.json',
-                      'quality_filtered_reads',
+                      'quality_filtered_reads_r1r2',
                       _parse_fastp_counts)
 
 
@@ -235,10 +236,10 @@ def run_counts(run_dir, metadata):
             minimap2_counts(run_dir, metadata)])
 
     # convenience columns to assess sample quality
-    out['fraction_passing_quality_filter'] = (out['quality_filtered_reads'] /
-                                              out['raw_reads'])
+    good_ratio = out['quality_filtered_reads_r1r2'] / out['raw_reads_r1r2']
+    out['fraction_passing_quality_filter'] = good_ratio
     out['fraction_non_human'] = (out['non_host_reads'] /
-                                 out['quality_filtered_reads'])
+                                 out['quality_filtered_reads_r1r2'])
 
     out.fillna(value='NA', inplace=True)
 

--- a/metapool/count.py
+++ b/metapool/count.py
@@ -236,8 +236,8 @@ def run_counts(run_dir, metadata):
             minimap2_counts(run_dir, metadata)])
 
     # convenience columns to assess sample quality
-    good_ratio = out['quality_filtered_reads_r1r2'] / out['raw_reads_r1r2']
-    out['fraction_passing_quality_filter'] = good_ratio
+    ratio = out['quality_filtered_reads_r1r2'] / out['raw_reads_r1r2']
+    out['fraction_passing_quality_filter'] = ratio
     out['fraction_non_human'] = (out['non_host_reads'] /
                                  out['quality_filtered_reads_r1r2'])
 

--- a/metapool/tests/test_count.py
+++ b/metapool/tests/test_count.py
@@ -192,12 +192,12 @@ class TestCount(TestCase):
     def test_bcl2fastq_counts(self):
         obs = bcl2fastq_counts(self.run_dir, self.ss)
         pd.testing.assert_frame_equal(obs.sort_index(),
-                                      self.stats[['raw_reads']])
+                                      self.stats[['raw_reads_r1r2']])
 
     def test_fastp_counts(self):
         obs = fastp_counts(self.run_dir, self.ss)
-        pd.testing.assert_frame_equal(obs.sort_index(),
-                                      self.stats[['quality_filtered_reads']])
+        exp = self.stats[['quality_filtered_reads_r1r2']]
+        pd.testing.assert_frame_equal(obs.sort_index(), exp)
 
     def test_minimap2_counts(self):
         obs = minimap2_counts(self.run_dir, self.ss)
@@ -210,17 +210,17 @@ class TestCount(TestCase):
 
 
 RUN_STATS = {
-    'raw_reads': {('sample1', '1'): 10000, ('sample2', '1'): 100000,
-                  ('sample1', '3'): 100000, ('sample2', '3'): 2300000,
-                  ('sample3', '3'): 300000, ('sample4', '3'): 400000,
-                  ('sample5', '3'): 567000},
-    'quality_filtered_reads': {('sample1', '1'): 10800.0,
-                               ('sample2', '1'): 61404.0,
-                               ('sample1', '3'): 335996.0,
-                               ('sample2', '3'): 18374.0,
-                               ('sample3', '3'): 4692.0,
-                               ('sample4', '3'): 960.0,
-                               ('sample5', '3'): 30846196.0},
+    'raw_reads_r1r2': {('sample1', '1'): 10000, ('sample2', '1'): 100000,
+                       ('sample1', '3'): 100000, ('sample2', '3'): 2300000,
+                       ('sample3', '3'): 300000, ('sample4', '3'): 400000,
+                       ('sample5', '3'): 567000},
+    'quality_filtered_reads_r1r2': {('sample1', '1'): 10800.0,
+                                    ('sample2', '1'): 61404.0,
+                                    ('sample1', '3'): 335996.0,
+                                    ('sample2', '3'): 18374.0,
+                                    ('sample3', '3'): 4692.0,
+                                    ('sample4', '3'): 960.0,
+                                    ('sample5', '3'): 30846196.0},
     'non_host_reads': {('sample1', '1'): 111172.0, ('sample2', '1'): 277611.0,
                        ('sample1', '3'): 1168275.0, ('sample2', '3'): 1277.0,
                        ('sample3', '3'): 33162.0, ('sample4', '3'): 2777.0,
@@ -310,7 +310,7 @@ class TestBCLConvertCount(TestCase):
     def test_bcl2fastq_counts(self):
         obs = bcl2fastq_counts(self.run_dir, self.ss)
 
-        exp = self.stats[['raw_reads']] * 2
+        exp = self.stats[['raw_reads_r1r2']] * 2
         pd.testing.assert_frame_equal(obs.sort_index(), exp)
 
     def tearDown(self):

--- a/metapool/tests/test_count.py
+++ b/metapool/tests/test_count.py
@@ -309,8 +309,9 @@ class TestBCLConvertCount(TestCase):
 
     def test_bcl2fastq_counts(self):
         obs = bcl2fastq_counts(self.run_dir, self.ss)
-        pd.testing.assert_frame_equal(obs.sort_index(),
-                                      self.stats[['raw_reads']])
+
+        exp = self.stats[['raw_reads']] * 2
+        pd.testing.assert_frame_equal(obs.sort_index(), exp)
 
     def tearDown(self):
         shutil.rmtree(self.run_dir)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ keywords = 'microbiome wetlab bioinformatics',
 
 base = ['numpy', 'pandas', 'matplotlib >= 2.0', 'seaborn >= 0.7.1', 'click',
         'sample_sheet', 'openpyxl', 'qiita_client @ https://github.com/'
-        'qiita-spots/qiita_client/archive/master.zip', 'scikit-learn']
+        'qiita-spots/qiita_client/archive/master.zip', 'scikit-learn',
+        'certifi']
 test = ["nose", "pep8", "flake8"]
 coverage = ['coverage']
 notebook = ['jupyter', 'notebook', 'jupyter_contrib_nbextensions', 'watermark']

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ keywords = 'microbiome wetlab bioinformatics',
 
 base = ['numpy', 'pandas', 'matplotlib >= 2.0', 'seaborn >= 0.7.1', 'click',
         'sample_sheet', 'openpyxl', 'qiita_client @ https://github.com/'
-        'qiita-spots/qiita_client/archive/master.zip', 'scikit-learn',
-        'certifi']
+        'qiita-spots/qiita_client/archive/master.zip', 'scikit-learn']
 test = ["nose", "pep8", "flake8"]
 coverage = ['coverage']
 notebook = ['jupyter', 'notebook', 'jupyter_contrib_nbextensions', 'watermark']


### PR DESCRIPTION
Simplest fix. Assumes we can always multiply the number of reads by 2. Does not pull raw_reads from fastp JSON files.
raw_reads count extraction previously was accounting only for half of the reads.