### PR TITLE
Removed sanity-check to support plate-level rep

### DIFF
--- a/metapool/count.py
+++ b/metapool/count.py
@@ -251,7 +251,6 @@ def count_sequences_in_fastq(file_path):
 def direct_sequence_counts(run_dir, metadata):
     if isinstance(metadata, metapool.KLSampleSheet):
         projects = {(s.Sample_Project, s.Lane) for s in metadata}
-        expected = {s.Sample_ID for s in metadata}
     else:
         raise ValueError("counts not implemented for amplicon")
 

--- a/metapool/count.py
+++ b/metapool/count.py
@@ -289,10 +289,6 @@ def direct_sequence_counts(run_dir, metadata):
 
             sample_id = m_r1[1]
 
-            if sample_id not in expected:
-                raise ValueError(f"'{sample_id}' does not match any sample-id"
-                                 "in sample-sheet")
-
             r1_counts = count_sequences_in_fastq(r1)
             r2_counts = count_sequences_in_fastq(r2)
 


### PR DESCRIPTION
Removed sanity-check that raises an error if run_counts() finds a fastq.gz file that isn't mentioned in the sample-sheet. This assumption does not hold during plate-level replication where new sample-sheets are created for each replicate. In this case, each new sample-sheet is by definition going to contain only a subset of the sample_ids found in the fastq.gz directory.