### PR TITLE
Add optional karatho control columns in [Data] section

### DIFF
--- a/metapool/__init__.py
+++ b/metapool/__init__.py
@@ -4,7 +4,8 @@ from .prep import (preparations_for_run, parse_prep, generate_qiita_prep_file,
                    demux_pre_prep, pre_prep_needs_demuxing)
 from .sample_sheet import (sample_sheet_to_dataframe, make_sample_sheet,
                            AmpliconSampleSheet, MetagenomicSampleSheetv90,
-                           MetagenomicSampleSheetv100, AbsQuantSampleSheetv10,
+                           MetagenomicSampleSheetv100,
+                           MetagenomicSampleSheetv101, AbsQuantSampleSheetv10,
                            MetatranscriptomicSampleSheetv0, demux_sample_sheet,
                            sheet_needs_demuxing, KLSampleSheet,
                            load_sample_sheet, MetatranscriptomicSampleSheetv10)
@@ -29,7 +30,8 @@ __all__ = ['IGMManifest', 'add_controls', 'assign_emp_index', 'autopool',
            'requires_dilution', 'run_counts', 'sample_sheet_to_dataframe',
            'sheet_needs_demuxing', 'sum_lanes', 'validate_plate_metadata',
            'MetagenomicSampleSheetv90', 'MetagenomicSampleSheetv100',
-           'AmpliconSampleSheet', 'MetatranscriptomicSampleSheetv0',
+           'MetagenomicSampleSheetv101', 'AmpliconSampleSheet',
+           'MetatranscriptomicSampleSheetv0',
            'MetatranscriptomicSampleSheetv10', 'AbsQuantSampleSheetv10',
            # KLSampleSheet is needed for instance() calls.
            'KLSampleSheet', 'load_sample_sheet']

--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -434,7 +434,7 @@ class KLSampleSheet(sample_sheet.SampleSheet):
         # been removed and non-essential columns have been dropped.
         out['Well_description'] = well_description
 
-        for column in self.get_sample_columns:
+        for column in self.get_sample_columns():
             if column not in out.columns:
                 warnings.warn('The column %s in the sample sheet is empty' %
                               column)
@@ -1178,7 +1178,7 @@ def load_sample_sheet(sample_sheet_path):
         return sheet
 
     sheet = MetagenomicSampleSheetv101(sample_sheet_path)
-    if sheet.validate_and_scrub_sample_sheet(echo_msgs=True):
+    if sheet.validate_and_scrub_sample_sheet(echo_msgs=False):
         return sheet
 
     sheet = MetagenomicSampleSheetv100(sample_sheet_path)

--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -882,9 +882,9 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
         # file. Hence, perform this check on demand() as opposed to once at
         # init().
         for sample in self.samples:
-            # assume any sample-name beginning with 'kath' in any form of
+            # assume any sample-name beginning with 'katharo' in any form of
             # case is a katharoseq sample.
-            if sample.Sample_Name.lower().startswith('kath'):
+            if sample.Sample_Name.lower().startswith('katharo'):
                 return True
 
         return False
@@ -895,7 +895,7 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
         # this helper method will return True only if a katharo-control
         # sample is found. Note criteria for this method should be kept
         # consistent w/the above method (contains_katharoseq_samples).
-        return table['Sample_Name'].str.startswith('kath').any()
+        return table['Sample_Name'].str.startswith('katharo').any()
 
     def _get_expected_columns(self, table=None):
         if table is None:

--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -870,7 +870,9 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
 
         self.contains_katharoseq_samples = False
         for sample in self.samples:
-            if sample.Sample_Name.startswith('KATHARO'):
+            # assume any sample-name beginning with 'kath' in any form of
+            # case is a katharoseq sample.
+            if sample.Sample_Name.lower().startswith('kath'):
                 self.contains_katharoseq_samples = True
                 break
 
@@ -1150,9 +1152,9 @@ def load_sample_sheet(sample_sheet_path):
     if sheet.validate_and_scrub_sample_sheet(echo_msgs=False):
         return sheet
 
-    # sheet = MetagenomicSampleSheetv101(sample_sheet_path)
-    # if sheet.validate_and_scrub_sample_sheet(echo_msgs=False):
-    #    return sheet
+    sheet = MetagenomicSampleSheetv101(sample_sheet_path)
+    if sheet.validate_and_scrub_sample_sheet(echo_msgs=False):
+        return sheet
 
     sheet = MetagenomicSampleSheetv90(sample_sheet_path)
     if sheet.validate_and_scrub_sample_sheet(echo_msgs=False):

--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -888,19 +888,26 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
             'Project Name': 'Sample_Project',
         }
 
-        self.contains_katharoseq_samples = False
+    def contains_katharoseq_samples(self):
+        # when creating samples manually, as opposed to loading a sample-sheet
+        # from file, whether or not a sample-sheet contains katharoseq
+        # controls can change from add_sample() to add_sample() and won't be
+        # determined when MetagenomicSampleSheetv101() is created w/out a
+        # file. Hence, perform this check on demand() as opposed to once at
+        # init().
         for sample in self.samples:
             # assume any sample-name beginning with 'kath' in any form of
             # case is a katharoseq sample.
             if sample.Sample_Name.lower().startswith('kath'):
-                self.contains_katharoseq_samples = True
-                break
+                return True
+
+        return False
 
     def get_sample_columns(self):
         # if [Data] section contains katharoseq samples, add the expected
         # additional katharoseq columns to the official list of expected
         # columns before validation or other processing begins.
-        if self.contains_katharoseq_samples:
+        if self.contains_katharoseq_samples():
             return self.data_columns + self.optional_katharoseq_columns
 
         return self.data_columns

--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -308,7 +308,7 @@ class KLSampleSheet(sample_sheet.SampleSheet):
                 if section is not None:
                     # these sections are represented as DataFrame objects
                     writer.writerow(pad_iterable(section.columns.tolist(),
-                                    csv_width))
+                                                 csv_width))
 
                     for _, row in section.iterrows():
                         writer.writerow(pad_iterable(row.values.tolist(),
@@ -405,7 +405,6 @@ class KLSampleSheet(sample_sheet.SampleSheet):
             # defined in each sample-sheet version. For newer classes, this is
             # defined at run-time and requires examining the metadata that
             # will define the [Data] section.
-            result.to_csv('result.csv')
             required_columns = self._get_expected_columns(table=result)
             subset = list(set(required_columns) & set(result.columns))
             result = result[subset]
@@ -837,14 +836,6 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
                     'I7_Index_ID', 'index', 'I5_Index_ID', 'index2',
                     'Sample_Project', 'Well_description']
 
-    # Names of columns needed in the sample-information-file output that is
-    # later passed into Qiita:
-    # 'katharoseq_aliquot_volume_ul',
-    # 'katharoseq_batch_information',
-    # 'katharoseq_cell_count',
-    # 'katharoseq_plate_number',
-    # 'katharoseq_strain'
-
     # columns present in an pre-prep file (amplicon) that included katharoseq
     # controls. Presumably we will need these same columns in a sample-sheet.
     optional_katharoseq_columns = ['Kathseq_RackID', 'TubeCode',
@@ -871,11 +862,6 @@ class MetagenomicSampleSheetv101(KLSampleSheet):
     def __init__(self, path=None):
         super().__init__(path=path)
         self.remapper = {
-            # TODO: It seems like the optional columns need to be defined in
-            # the remapper, even if they map to itself - this will let those
-            # columns pass through remapper if they're present, even on strict
-            # setting. Unconfirmed if it will blow up if the columns aren't
-            # present but I think it should be okay.
             'sample sheet Sample_ID': 'Sample_ID',
             'Sample': 'Sample_Name',
             'Project Plate': 'Sample_Plate',
@@ -951,8 +937,8 @@ class MetagenomicSampleSheetv100(KLSampleSheet):
                     'I7_Index_ID', 'index', 'I5_Index_ID', 'index2',
                     'Sample_Project', 'Well_description']
 
-    # For now, assume only MetagenomicSampleSheetv101, v100, v95, v99 contains
-    # 'contains_replicates' column. Assume AbsQuantSampleSheetv10 doesn't.
+    # For now, assume only AbsQuantSampleSheetv10 doesn't contain
+    # 'contains_replicates' column, while the others do.
 
     _BIOINFORMATICS_COLUMNS = {'Sample_Project', 'QiitaID', 'BarcodesAreRC',
                                'ForwardAdapter', 'ReverseAdapter',
@@ -1338,10 +1324,6 @@ def make_sample_sheet(metadata, table, sequencer, lanes, strict=True):
 
     if len(messages) == 0:
         sheet._add_metadata_to_sheet(metadata, sequencer)
-
-        # the problem is that _add_data_to_sheet() is not adding all of the
-        # required columns - is it because they're not beign supplied or it
-        # doesn't know to add them in this case? We need to find out! TODO
         sheet._add_data_to_sheet(table, sequencer, lanes, metadata['Assay'],
                                  strict)
 

--- a/metapool/tests/data/test_katharoseq_sheet1.csv
+++ b/metapool/tests/data/test_katharoseq_sheet1.csv
@@ -1,0 +1,38 @@
+[Header],,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,
+SheetType,standard_metag,,,,,,,,,
+SheetVersion,101,,,,,,,,,
+Investigator Name,Knight,,,,,,,,,
+Experiment Name,RKL0042,,,,,,,,,
+Date,2/26/24,,,,,,,,,
+Workflow,GenerateFASTQ,,,,,,,,,
+Application,FASTQ Only,,,,,,,,,
+Assay,Metagenomic,,,,,,,,,
+Description,,,,,,,,,,
+Chemistry,Default,,,,,,,,,
+,,,,,,,,,,
+[Reads],,,,,,,,,,
+150,,,,,,,,,,
+150,,,,,,,,,,
+,,,,,,,,,,
+[Settings],,,,,,,,,,
+ReverseComplement,0,,,,,,,,,
+MaskShortReads,1,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,
+,,,,,,,,,,
+[Data],,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,well_id_384,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Well_description
+1,SAMPLE_1,SAMPLE-1,MyProject_99999_P40,A1,iTru7_107_07,CCGACTAT,iTru5_01_A,ACCGACAA,MyProject_99999,this is a description
+1,SAMPLE_2,SAMPLE-2,MyProject_99999_P40,C1,iTru7_107_08,CCGACTAT,iTru5_02_A,CTTCGCAA,MyProject_99999,this is a description
+1,SAMPLE_3,SAMPLE-3,MyProject_99999_P40,E1,iTru7_107_09,GCCTTGTT,iTru5_03_A,AACACCAC,MyProject_99999,this is a description
+1,SAMPLE_4,SAMPLE-4,MyProject_99999_P40,G1,iTru7_107_10,AACTTGCC,iTru5_04_A,CGTATCTC,MyProject_99999,this is a description
+1,SAMPLE_5,SAMPLE-5,MyProject_99999_P40,I1,iTru7_107_11,CAATGTGG,iTru5_05_A,GGTACGAA,MyProject_99999,this is a description
+,,,,,,,,,,
+[Bioinformatics],,,,,,,,,,
+Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapter,HumanFiltering,library_construction_protocol,experiment_design_description,,,
+MyProject_99999,11661,FALSE,AACC,GGTT,FALSE,Knight Lab Kapa HP,description1,,,
+,,,,,,,,,,
+[Contact],,,,,,,,,,
+Email,Sample_Project,,,,,,,,,
+foo@bar.com,MyProject_99999,,,,,,,,,
+,,,,,,,,,,

--- a/metapool/tests/data/test_katharoseq_sheet2.csv
+++ b/metapool/tests/data/test_katharoseq_sheet2.csv
@@ -27,9 +27,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,well_id_384,I7_Index_ID,index,I5_Index_I
 1,SAMPLE_3,SAMPLE-3,MyProject_99999_P40,E1,iTru7_107_09,GCCTTGTT,iTru5_03_A,AACACCAC,MyProject_99999,,,,,,,,,this is a description
 1,SAMPLE_4,SAMPLE-4,MyProject_99999_P40,G1,iTru7_107_10,AACTTGCC,iTru5_04_A,CGTATCTC,MyProject_99999,,,,,,,,,this is a description
 1,SAMPLE_5,SAMPLE-5,MyProject_99999_P40,I1,iTru7_107_11,CAATGTGG,iTru5_05_A,GGTACGAA,MyProject_99999,,,,,,,,,this is a description
-1,kathseq_18000_0_E11,kathseq.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
-1,kathseq_4800_0_E12,kathseq.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
-1,kathseq_960_0_F1,kathseq.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
+1,katharo_18000_0_E11,katharo.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
+1,katharo_4800_0_E12,katharo.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
+1,katharo_960_0_F1,katharo.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
 ,,,,,,,,,,,,,,,,,,
 [Bioinformatics],,,,,,,,,,,,,,,,,,
 Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapter,HumanFiltering,library_construction_protocol,experiment_design_description,,,,,,,,,,,

--- a/metapool/tests/data/test_katharoseq_sheet2.csv
+++ b/metapool/tests/data/test_katharoseq_sheet2.csv
@@ -1,0 +1,40 @@
+[Header],,,,,,,,,,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,,,,,,,,,
+SheetType,standard_metag,,,,,,,,,,,,,,,,,
+SheetVersion,101,,,,,,,,,,,,,,,,,
+Investigator Name,Knight,,,,,,,,,,,,,,,,,
+Experiment Name,RKL0042,,,,,,,,,,,,,,,,,
+Date,2/26/24,,,,,,,,,,,,,,,,,
+Workflow,GenerateFASTQ,,,,,,,,,,,,,,,,,
+Application,FASTQ Only,,,,,,,,,,,,,,,,,
+Assay,Metagenomic,,,,,,,,,,,,,,,,,
+Description,,,,,,,,,,,,,,,,,,
+Chemistry,Default,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Reads],,,,,,,,,,,,,,,,,,
+150,,,,,,,,,,,,,,,,,,
+150,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Settings],,,,,,,,,,,,,,,,,,
+ReverseComplement,0,,,,,,,,,,,,,,,,,
+MaskShortReads,1,,,,,,,,,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Data],,,,,,,,,,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,well_id_384,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Kathseq_RackID,TubeCode,katharo_description,number_of_cells,platemap_generation_date,project_abbreviation,vol_extracted_elution_ul,well_id_96,Well_description
+1,SAMPLE_1,SAMPLE-1,MyProject_99999_P40,A1,iTru7_107_07,CCGACTAT,iTru5_01_A,ACCGACAA,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_2,SAMPLE-2,MyProject_99999_P40,C1,iTru7_107_08,CCGACTAT,iTru5_02_A,CTTCGCAA,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_3,SAMPLE-3,MyProject_99999_P40,E1,iTru7_107_09,GCCTTGTT,iTru5_03_A,AACACCAC,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_4,SAMPLE-4,MyProject_99999_P40,G1,iTru7_107_10,AACTTGCC,iTru5_04_A,CGTATCTC,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_5,SAMPLE-5,MyProject_99999_P40,I1,iTru7_107_11,CAATGTGG,iTru5_05_A,GGTACGAA,MyProject_99999,,,,,,,,,this is a description
+1,kathseq_18000_0_E11,kathseq.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
+1,kathseq_4800_0_E12,kathseq.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
+1,kathseq_960_0_F1,kathseq.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
+,,,,,,,,,,,,,,,,,,
+[Bioinformatics],,,,,,,,,,,,,,,,,,
+Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapter,HumanFiltering,library_construction_protocol,experiment_design_description,,,,,,,,,,,
+MyProject_99999,11661,FALSE,AACC,GGTT,FALSE,Knight Lab Kapa HP,description1,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Contact],,,,,,,,,,,,,,,,,,
+Email,Sample_Project,,,,,,,,,,,,,,,,,
+foo@bar.com,MyProject_99999,,,,,,,,,,,,,,,,,

--- a/metapool/tests/data/test_katharoseq_sheet3.csv
+++ b/metapool/tests/data/test_katharoseq_sheet3.csv
@@ -1,0 +1,40 @@
+[Header],,,,,,,,,,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,,,,,,,,,
+SheetType,standard_metag,,,,,,,,,,,,,,,,,
+SheetVersion,101,,,,,,,,,,,,,,,,,
+Investigator Name,Knight,,,,,,,,,,,,,,,,,
+Experiment Name,RKL0042,,,,,,,,,,,,,,,,,
+Date,2/26/24,,,,,,,,,,,,,,,,,
+Workflow,GenerateFASTQ,,,,,,,,,,,,,,,,,
+Application,FASTQ Only,,,,,,,,,,,,,,,,,
+Assay,Metagenomic,,,,,,,,,,,,,,,,,
+Description,,,,,,,,,,,,,,,,,,
+Chemistry,Default,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Reads],,,,,,,,,,,,,,,,,,
+150,,,,,,,,,,,,,,,,,,
+150,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Settings],,,,,,,,,,,,,,,,,,
+ReverseComplement,0,,,,,,,,,,,,,,,,,
+MaskShortReads,1,,,,,,,,,,,,,,,,,
+OverrideCycles,Y151;I8N2;I8N2;Y151,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Data],,,,,,,,,,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,well_id_384,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Kathseq_RackID,TubeCode,katharo_description,number_of_sells,platemap_generation_date,project_abbreviation,vol_extracted_elution_ul,well_id_96,Well_description
+1,SAMPLE_1,SAMPLE-1,MyProject_99999_P40,A1,iTru7_107_07,CCGACTAT,iTru5_01_A,ACCGACAA,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_2,SAMPLE-2,MyProject_99999_P40,C1,iTru7_107_08,CCGACTAT,iTru5_02_A,CTTCGCAA,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_3,SAMPLE-3,MyProject_99999_P40,E1,iTru7_107_09,GCCTTGTT,iTru5_03_A,AACACCAC,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_4,SAMPLE-4,MyProject_99999_P40,G1,iTru7_107_10,AACTTGCC,iTru5_04_A,CGTATCTC,MyProject_99999,,,,,,,,,this is a description
+1,SAMPLE_5,SAMPLE-5,MyProject_99999_P40,I1,iTru7_107_11,CAATGTGG,iTru5_05_A,GGTACGAA,MyProject_99999,,,,,,,,,this is a description
+1,kathseq_18000_0_E11,kathseq.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
+1,kathseq_4800_0_E12,kathseq.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
+1,kathseq_960_0_F1,kathseq.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
+,,,,,,,,,,,,,,,,,,
+[Bioinformatics],,,,,,,,,,,,,,,,,,
+Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapter,HumanFiltering,library_construction_protocol,experiment_design_description,,,,,,,,,,,
+MyProject_99999,11661,FALSE,AACC,GGTT,FALSE,Knight Lab Kapa HP,description1,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,
+[Contact],,,,,,,,,,,,,,,,,,
+Email,Sample_Project,,,,,,,,,,,,,,,,,
+foo@bar.com,MyProject_99999,,,,,,,,,,,,,,,,,

--- a/metapool/tests/data/test_katharoseq_sheet3.csv
+++ b/metapool/tests/data/test_katharoseq_sheet3.csv
@@ -27,9 +27,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,well_id_384,I7_Index_ID,index,I5_Index_I
 1,SAMPLE_3,SAMPLE-3,MyProject_99999_P40,E1,iTru7_107_09,GCCTTGTT,iTru5_03_A,AACACCAC,MyProject_99999,,,,,,,,,this is a description
 1,SAMPLE_4,SAMPLE-4,MyProject_99999_P40,G1,iTru7_107_10,AACTTGCC,iTru5_04_A,CGTATCTC,MyProject_99999,,,,,,,,,this is a description
 1,SAMPLE_5,SAMPLE-5,MyProject_99999_P40,I1,iTru7_107_11,CAATGTGG,iTru5_05_A,GGTACGAA,MyProject_99999,,,,,,,,,this is a description
-1,kathseq_18000_0_E11,kathseq.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
-1,kathseq_4800_0_E12,kathseq.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
-1,kathseq_960_0_F1,kathseq.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
+1,katharo_18000_0_E11,katharo.18000.0.E11,MyProject_99999_P40,A2,iTru7_107_12,CAATGTGA,iTru5_05_A,GGTACGAT,MyProject_99999,1,1,positive_control,98765432,2/10/24,ADAPT,115,F1,this is a description
+1,katharo_4800_0_E12,katharo.4800.0.E12,MyProject_99999_P40,C2,iTru7_107_13,AATGTACC,iTru5_05_A,AAATTTTA,MyProject_99999,2,2,positive_control,98765432,2/10/24,ADAPT,192,F2,this is a description
+1,katharo_960_0_F1,katharo.960.0.F1,MyProject_99999_P40,E2,iTru7_107_14,GCTATGCA,iTru5_05_A,CCGGTTAA,MyProject_99999,3,3,positive_control,98765432,2/10/24,ADAPT,38,F3,this is a description
 ,,,,,,,,,,,,,,,,,,
 [Bioinformatics],,,,,,,,,,,,,,,,,,
 Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapter,HumanFiltering,library_construction_protocol,experiment_design_description,,,,,,,,,,,

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1817,8 +1817,8 @@ class AdditionalSampleSheetCreationTests(BaseTests):
                       ' Data section is missing', msgs)
 
     def test_katharoseq_enabled_sheet_creation(self):
-        # create a Metagenomic-type sample-sheet from scratch and manually
-        # populate the required fields.
+        # create a Metagenomic-type sample-sheet from scratch w/out karathoseq
+        # samples and manually populate the required fields.
         sheet = MetagenomicSampleSheetv101()
         sheet.Header['IEMFileVersion'] = 4
         sheet.Header['SheetType'] = 'standard_metag'
@@ -1870,8 +1870,8 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         # Once sheet has been manually populated, validate it.
         self.assertTrue(sheet.validate_and_scrub_sample_sheet())
 
-        # create a Metagenomic-type sample-sheet from scratch and manually
-        # populate the required fields.
+        # create another sheet from scratch, this time with karathoseq
+        # samples.
         sheet = MetagenomicSampleSheetv101()
         sheet.Header['IEMFileVersion'] = 4
         sheet.Header['SheetType'] = 'standard_metag'
@@ -1913,15 +1913,15 @@ class AdditionalSampleSheetCreationTests(BaseTests):
              'CCGACTAC', 'iTru5_01_A', 'ACCGACAT', 'Project1_99999', 'desc'],
             ['sample_3', 'sample.3', 'sample_plate_1', 'A3', 'iTru7_107_07',
              'CCGACTAG', 'iTru5_01_A', 'ACCGACAG', 'Project1_99999', 'desc'],
+            ['kath0001', 'kath0001', 'sample_plate_1', 'A4', 'iTru7_107_07',
+             'CCGCCTAG', 'iTru5_01_A', 'ACCGTCAG', 'Project1_99999', 'desc']
         ]
 
         for row in data:
-            # Add each row as a Sample() object. Each Sample() object takes
-            # a dict as its initializer.
+            # TODO: add_sample() needs overloading & handling to dynamically
+            #  adjust the number of columns after seeing the first karathoseq
+            #  sample and performing error-handling.
             sheet.add_sample(sample_sheet.Sample(dict(zip(header, row))))
-
-        # Once sheet has been manually populated, validate it.
-        self.assertTrue(sheet.validate_and_scrub_sample_sheet())
 
 
 DF_DATA = [

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1863,6 +1863,10 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
                'platemap_generation_date', 'project_abbreviation',
                'vol_extracted_elution_ul', 'well_id_96']
         obs = sheet2._get_expected_columns()
+
+        print("EXP: %s" % exp)
+        print("OBS: %s" % obs)
+        # CHARLIE
         self.assertEqual(obs, exp)
         self.assertTrue(sheet1.validate_and_scrub_sample_sheet())
 
@@ -1979,8 +1983,9 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
             ['sample_3', 'sample.3', 'sample_plate_1', 'A3', 'iTru7_107_07',
              'CCGACTAG', 'iTru5_01_A', 'ACCGACAG', 'Project1_99999', 'desc'],
             # added katharoseq control here.
-            ['kath0001', 'kath0001', 'sample_plate_1', 'A4', 'iTru7_107_07',
-             'CCGCCTAG', 'iTru5_01_A', 'ACCGTCAG', 'Project1_99999', 'desc']
+            ['katharo0001', 'katharo0001', 'sample_plate_1', 'A4',
+             'iTru7_107_07', 'CCGCCTAG', 'iTru5_01_A', 'ACCGTCAG',
+             'Project1_99999', 'desc']
         ]
 
         for row in data:
@@ -1991,7 +1996,7 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
             #
             # We can assume that a user creating a katharoseq-enabled
             # sample-sheet will include the katharoseq-enabled columns, even
-            # for sample-names that don't begin with 'kath'.
+            # for sample-names that don't begin with 'katharo'.
             #
             # Hence, as when using load_sample_sheet(), confirmation that
             # katharoseq columns are present when katharoseq controls are in
@@ -2037,9 +2042,9 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
              'CCGACTAG', 'iTru5_01_A', 'ACCGACAG', 'Project1_99999', 'desc',
              '', '', '', '', '', '', '', ''],
             # added katharoseq control here.
-            ['kath0001', 'kath0001', 'sample_plate_1', 'A4', 'iTru7_107_07',
-             'CCGCCTAG', 'iTru5_01_A', 'ACCGTCAG', 'Project1_99999', 'desc',
-             '', '', '', '', '', '', '', '']
+            ['katharo0001', 'katharo0001', 'sample_plate_1', 'A4',
+             'iTru7_107_07', 'CCGCCTAG', 'iTru5_01_A', 'ACCGTCAG',
+             'Project1_99999', 'desc', '', '', '', '', '', '', '', '']
         ]
 
         for row in data:
@@ -2050,7 +2055,7 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
             #
             # We can assume that a user creating a katharoseq-enabled
             # sample-sheet will include the katharoseq-enabled columns, even
-            # for sample-names that don't begin with 'kath'.
+            # for sample-names that don't begin with 'katharo'.
             #
             # Hence, as when using load_sample_sheet(), confirmation that
             # katharoseq columns are present when katharoseq controls are in
@@ -2106,8 +2111,8 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
         # dataset that has only one of the optional columns (Kathseq_RackID)
         # included. This should result in an error raised.
 
-        # To do this, we will change the name of the sample to begin w/kath.
-        self.data[0][1] = 'kath.01'  # changing sample_name
+        # To do this, we will change the name of the sample to begin w/katharo.
+        self.data[0][1] = 'katharo.01'  # changing sample_name
 
         table = pd.DataFrame(columns=self.input_columns, data=self.data)
 
@@ -2127,8 +2132,8 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
 
     def test_katharoseq_make_sample_sheet_all_optional_columns(self):
         # test make_sample_sheet() w/katharoseq data. To do this, change the
-        # name of the sample to begin w/kath.
-        self.data[0][1] = 'kath.01'  # changing sample_name
+        # name of the sample to begin w/katharo.
+        self.data[0][1] = 'katharo.01'  # changing sample_name
 
         # add missing columns to the data and populate them with 'junk value'.
         optional_columns = ['Kathseq_RackID', 'TubeCode',

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1864,9 +1864,6 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
                'vol_extracted_elution_ul', 'well_id_96']
         obs = sheet2._get_expected_columns()
 
-        print("EXP: %s" % exp)
-        print("OBS: %s" % obs)
-        # CHARLIE
         self.assertEqual(obs, exp)
         self.assertTrue(sheet1.validate_and_scrub_sample_sheet())
 

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -2182,6 +2182,7 @@ class AdditionalSampleSheetCreationTests(BaseTests):
                        'vol_extracted_elution_ul', 'Lane'}
 
         self.assertEqual(obs_columns, exp_columns)
+        self.assertTrue(sheet.validate_and_scrub_sample_sheet())
 
 
 DF_DATA = [

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1806,6 +1806,35 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
              'CMGCCGCGGTAA', 'pool1']
         ]
 
+        self.test_sheet = MetagenomicSampleSheetv101()
+        self.test_sheet.Header['IEMFileVersion'] = 4
+        self.test_sheet.Header['sheetType'] = 'standard_metag'
+        self.test_sheet.Header['sheetVersion'] = '101'
+        self.test_sheet.Header['Investigator Name'] = 'Knight'
+        self.test_sheet.Header['Experiment Name'] = 'RKO_experiment'
+        self.test_sheet.Header['Date'] = '2021-08-17'
+        self.test_sheet.Header['Workflow'] = 'GenerateFASTQ'
+        self.test_sheet.Header['Application'] = 'FASTQ Only'
+        self.test_sheet.Header['Assay'] = 'Metagenomic'
+        self.test_sheet.Header['Description'] = ''
+        self.test_sheet.Header['Chemistry'] = 'Default'
+        self.test_sheet.Reads = [151, 151]
+        self.test_sheet.Settings['ReverseComplement'] = 0
+
+        self.test_sheet.Bioinformatics = pd.DataFrame(
+            columns=['Sample_Project', 'QiitaID', 'BarcodesAreRC',
+                     'ForwardAdapter', 'ReverseAdapter', 'HumanFiltering',
+                     'contains_replicates', 'library_construction_protocol',
+                     'experiment_design_description'], data=[
+                ['Project1_99999', '99999', 'False', 'AACC', 'GGTT', 'False',
+                 'False', 'protocol_1', 'a designed experiment']
+            ])
+
+        self.test_sheet.Contact = pd.DataFrame(
+            columns=['Email', 'Sample_Project'],
+            data=[['c2cowart@ucsd.edu',
+                   'Project1_99999'], ])
+
     def test_katharoseq_enabled_sheet_load(self):
         # load metagenomic sample-sheet w/out katharoseq samples in the [Data]
         # section, and get a list of the columns.
@@ -1938,36 +1967,6 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
 
     def test_katharoseq_enabled_sheet_creation(self):
         # create a sheet from scratch, this time with karathoseq samples.
-        sheet = MetagenomicSampleSheetv101()
-        sheet.Header['IEMFileVersion'] = 4
-        sheet.Header['sheetType'] = 'standard_metag'
-        sheet.Header['sheetVersion'] = '101'
-        sheet.Header['Investigator Name'] = 'Knight'
-        sheet.Header['Experiment Name'] = 'RKO_experiment'
-        sheet.Header['Date'] = '2021-08-17'
-        sheet.Header['Workflow'] = 'GenerateFASTQ'
-        sheet.Header['Application'] = 'FASTQ Only'
-        sheet.Header['Assay'] = 'Metagenomic'
-        sheet.Header['Description'] = ''
-        sheet.Header['Chemistry'] = 'Default'
-        sheet.Reads = [151, 151]
-        sheet.Settings['ReverseComplement'] = 0
-
-        data = [
-            ['Project1_99999', '99999', 'False', 'AACC', 'GGTT', 'False',
-             'False', 'protocol_1', 'a designed experiment']
-        ]
-
-        sheet.Bioinformatics = pd.DataFrame(
-            columns=['Sample_Project', 'QiitaID', 'BarcodesAreRC',
-                     'ForwardAdapter', 'ReverseAdapter', 'HumanFiltering',
-                     'contains_replicates', 'library_construction_protocol',
-                     'experiment_design_description'], data=data)
-
-        sheet.Contact = pd.DataFrame(columns=['Email', 'Sample_Project'],
-                                     data=[['c2cowart@ucsd.edu',
-                                            'Project1_99999'], ])
-
         header = ['Sample_ID', 'Sample_Name', 'Sample_Plate', 'well_id_384',
                   'I7_Index_ID', 'index', 'I5_Index_ID', 'index2',
                   'Sample_Project', 'Well_description']
@@ -1998,17 +1997,18 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
             # katharoseq columns are present when katharoseq controls are in
             # the [Data] section and not present otherwise won't be determined
             # until validation() is called.
-            sheet.add_sample(sample_sheet.Sample(dict(zip(header, row))))
+            self.test_sheet.add_sample(sample_sheet.Sample(dict(zip(header,
+                                                                    row))))
 
         # sheet should not be valid, since we added a katharoseq control w/out
         # adding the additional columns.
-        self.assertFalse(sheet.validate_and_scrub_sample_sheet())
+        self.assertFalse(self.test_sheet.validate_and_scrub_sample_sheet())
 
         # confirm that a katharoseq control was found among the samples.
-        self.assertTrue(sheet.contains_katharoseq_samples())
+        self.assertTrue(self.test_sheet.contains_katharoseq_samples())
 
         # validate sheet again, this time get the list of error messages.
-        msgs = sheet.quiet_validate_and_scrub_sample_sheet()
+        msgs = self.test_sheet.quiet_validate_and_scrub_sample_sheet()
         msgs = [str(msg) for msg in msgs]
 
         # assert this message is present in the results, and assume all of the
@@ -2019,36 +2019,6 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
     def test_katharoseq_enabled_sheet_creation_manual(self):
         # create a sheet manually, this time with the proper type and
         # number of columns.
-        sheet = MetagenomicSampleSheetv101()
-        sheet.Header['IEMFileVersion'] = 4
-        sheet.Header['sheetType'] = 'standard_metag'
-        sheet.Header['sheetVersion'] = '101'
-        sheet.Header['Investigator Name'] = 'Knight'
-        sheet.Header['Experiment Name'] = 'RKO_experiment'
-        sheet.Header['Date'] = '2021-08-17'
-        sheet.Header['Workflow'] = 'GenerateFASTQ'
-        sheet.Header['Application'] = 'FASTQ Only'
-        sheet.Header['Assay'] = 'Metagenomic'
-        sheet.Header['Description'] = ''
-        sheet.Header['Chemistry'] = 'Default'
-        sheet.Reads = [151, 151]
-        sheet.Settings['ReverseComplement'] = 0
-
-        data = [
-            ['Project1_99999', '99999', 'False', 'AACC', 'GGTT', 'False',
-             'False', 'protocol_1', 'a designed experiment']
-        ]
-
-        sheet.Bioinformatics = pd.DataFrame(
-            columns=['Sample_Project', 'QiitaID', 'BarcodesAreRC',
-                     'ForwardAdapter', 'ReverseAdapter', 'HumanFiltering',
-                     'contains_replicates', 'library_construction_protocol',
-                     'experiment_design_description'], data=data)
-
-        sheet.Contact = pd.DataFrame(columns=['Email', 'Sample_Project'],
-                                     data=[['c2cowart@ucsd.edu',
-                                            'Project1_99999'], ])
-
         header = ['Sample_ID', 'Sample_Name', 'Sample_Plate', 'well_id_384',
                   'I7_Index_ID', 'index', 'I5_Index_ID', 'index2',
                   'Sample_Project', 'Well_description', 'Kathseq_RackID',
@@ -2086,11 +2056,12 @@ class KarathoseqEnabledSheetCreationTests(BaseTests):
             # katharoseq columns are present when katharoseq controls are in
             # the [Data] section and not present otherwise won't be determined
             # until validation() is called.
-            sheet.add_sample(sample_sheet.Sample(dict(zip(header, row))))
+            self.test_sheet.add_sample(sample_sheet.Sample(dict(zip(header,
+                                                                    row))))
 
-        self.assertTrue(sheet.validate_and_scrub_sample_sheet())
-        self.assertTrue(sheet.contains_katharoseq_samples())
-        msgs = sheet.quiet_validate_and_scrub_sample_sheet()
+        self.assertTrue(self.test_sheet.validate_and_scrub_sample_sheet())
+        self.assertTrue(self.test_sheet.contains_katharoseq_samples())
+        msgs = self.test_sheet.quiet_validate_and_scrub_sample_sheet()
         self.assertEqual([], msgs)
 
     def test_katharoseq_make_sample_sheet(self):

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -894,7 +894,7 @@ class SampleSheetWorkflow(BaseTests):
         message = (r'The column (I5_Index_ID|index2) '
                    r'in the sample sheet is empty')
         with self.assertWarnsRegex(UserWarning, message):
-            # because obs is generated from self.table (a pre-prep df), w
+            # because obs is generated from self.table (a pre-prep df), we
             # expect 'Well_description' to be empty since it is created and
             # populated before _remap_table() is called.
             sheet = AmpliconSampleSheet()
@@ -1549,15 +1549,6 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         self.metat_fp = join('metapool', 'tests', 'data',
                              'standard_metaT_samplesheet.csv')
 
-        self.katharoseq_1 = join('metapool', 'tests', 'data',
-                                 'test_katharoseq_sheet1.csv')
-
-        self.katharoseq_2 = join('metapool', 'tests', 'data',
-                                 'test_katharoseq_sheet2.csv')
-
-        self.katharoseq_3 = join('metapool', 'tests', 'data',
-                                 'test_katharoseq_sheet3.csv')
-
     def test_metatranscriptomic_sheet_creation(self):
         # create a Metatranscriptomic-type sample-sheet from scratch and
         # manually populate the required fields.
@@ -1750,6 +1741,71 @@ class AdditionalSampleSheetCreationTests(BaseTests):
 
         self.assertEqual(obs, exp)
 
+
+class KarathoseqEnabledSheetCreationTests(BaseTests):
+    def setUp(self):
+        self.katharoseq_1 = join('metapool', 'tests', 'data',
+                                 'test_katharoseq_sheet1.csv')
+
+        self.katharoseq_2 = join('metapool', 'tests', 'data',
+                                 'test_katharoseq_sheet2.csv')
+
+        self.katharoseq_3 = join('metapool', 'tests', 'data',
+                                 'test_katharoseq_sheet3.csv')
+
+        self.input_columns = ['sample sheet Sample_ID',
+                              'Sample', 'Row', 'Col', 'Blank', 'Project Plate',
+                              'Project Name', 'Compressed Plate Name', 'Well',
+                              'Plate Position', 'Primer Plate #', 'Plating',
+                              'Extraction Kit Lot', 'Extraction Robot',
+                              'TM1000 8 Tool', 'Primer Date', 'MasterMix Lot',
+                              'Water Lot', 'Processing Robot', 'Sample Plate',
+                              'Project_Name', 'Original Name', 'Plate',
+                              'EMP Primer Plate Well', 'Name',
+                              "Illumina 5' Adapter", 'Golay Barcode',
+                              'Forward Primer Pad', 'Forward Primer Linker',
+                              '515FB Forward Primer (Parada)',
+                              'Primer For PCR', 'syndna_pool_number']
+
+        self.metadata = {
+            'Bioinformatics': [
+                {
+                    'Sample_Project': 'MyProject_99999',
+                    'QiitaID': '101',
+                    'BarcodesAreRC': 'False',
+                    'ForwardAdapter': 'GATACA',
+                    'ReverseAdapter': 'CATCAT',
+                    'HumanFiltering': 'False',
+                    'library_construction_protocol': 'Knight Lab Kapa HP',
+                    'experiment_design_description': 'some description',
+                    'contains_replicates': 'False'
+                }
+            ],
+            'Contact': [
+                {
+                    'Sample_Project': 'MyProject_99999',
+                    'Email': 'foo@bar.org'
+                }
+            ],
+            'Assay': 'Metagenomic',
+            'SheetType': 'standard_metag',
+            'SheetVersion': '101'
+        }
+
+        self.data = [
+            ['sample1', 'sample1', 'A', 1, False, 'THDMI_10317_PUK2',
+             'MyProject_99999', 'THDMI_10317_UK2-US6', 'A1', '1', '1',
+             'SF',
+             '166032128', 'Carmen_HOWE_KF3', '109379Z', '2021-08-17',
+             '978215',
+             'RNBJ0628', 'Echo550', 'THDMI_UK_Plate_2', 'THDMI UK', '',
+             '1',
+             'A1', '515rcbc0', 'AATGATACGGCGACCACCGAGATCTACACGCT',
+             'AGCCTTCGTCGC', 'TATGGTAATT', 'GT', 'GTGYCAGCMGCCGCGGTAA',
+             'AATGATACGGCGACCACCGAGATCTACACGCTAGCCTTCGTCGCTATGGTAATTGTGTGYCAG'
+             'CMGCCGCGGTAA', 'pool1']
+        ]
+
     def test_katharoseq_enabled_sheet_load(self):
         # load metagenomic sample-sheet w/out katharoseq samples in the [Data]
         # section, and get a list of the columns.
@@ -1825,7 +1881,7 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         self.assertIn('ErrorMessage: The number_of_cells column in the'
                       ' Data section is missing', msgs)
 
-    def test_katharoseq_enabled_sheet_creation(self):
+    def test_katharoseq_enabled_sheet_creation_no_kath(self):
         # create a Metagenomic-type sample-sheet from scratch w/out karathoseq
         # samples and manually populate the required fields.
         sheet = MetagenomicSampleSheetv101()
@@ -1880,10 +1936,8 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         self.assertTrue(sheet.validate_and_scrub_sample_sheet())
         self.assertFalse(sheet.contains_katharoseq_samples())
 
-        ###
-
-        # create another sheet from scratch, this time with karathoseq
-        # samples.
+    def test_katharoseq_enabled_sheet_creation(self):
+        # create a sheet from scratch, this time with karathoseq samples.
         sheet = MetagenomicSampleSheetv101()
         sheet.Header['IEMFileVersion'] = 4
         sheet.Header['sheetType'] = 'standard_metag'
@@ -1962,9 +2016,8 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         self.assertIn('ErrorMessage: The TubeCode column in the Data section '
                       'is missing', msgs)
 
-        ###
-
-        # create one final sheet manually, this time with the proper type and
+    def test_katharoseq_enabled_sheet_creation_manual(self):
+        # create a sheet manually, this time with the proper type and
         # number of columns.
         sheet = MetagenomicSampleSheetv101()
         sheet.Header['IEMFileVersion'] = 4
@@ -2041,57 +2094,9 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         self.assertEqual([], msgs)
 
     def test_katharoseq_make_sample_sheet(self):
-        metadata = {
-            'Bioinformatics': [
-                {
-                    'Sample_Project': 'MyProject_99999',
-                    'QiitaID': '101',
-                    'BarcodesAreRC': 'False',
-                    'ForwardAdapter': 'GATACA',
-                    'ReverseAdapter': 'CATCAT',
-                    'HumanFiltering': 'False',
-                    'library_construction_protocol': 'Knight Lab Kapa HP',
-                    'experiment_design_description': 'some description',
-                    'contains_replicates': 'False'
-                }
-            ],
-            'Contact': [
-                {
-                    'Sample_Project': 'MyProject_99999',
-                    'Email': 'foo@bar.org'
-                }
-            ],
-            'Assay': 'Metagenomic',
-            'SheetType': 'standard_metag',
-            'SheetVersion': '101'
-        }
-
-        data = [
-            ['sample1', 'sample1', 'A', 1, False, 'THDMI_10317_PUK2',
-             'MyProject_99999', 'THDMI_10317_UK2-US6', 'A1', '1', '1', 'SF',
-             '166032128', 'Carmen_HOWE_KF3', '109379Z', '2021-08-17', '978215',
-             'RNBJ0628', 'Echo550', 'THDMI_UK_Plate_2', 'THDMI UK', '', '1',
-             'A1', '515rcbc0', 'AATGATACGGCGACCACCGAGATCTACACGCT',
-             'AGCCTTCGTCGC', 'TATGGTAATT', 'GT', 'GTGYCAGCMGCCGCGGTAA',
-             'AATGATACGGCGACCACCGAGATCTACACGCTAGCCTTCGTCGCTATGGTAATTGTGTGYCAG'
-             'CMGCCGCGGTAA', 'pool1']
-        ]
-
-        columns = ['sample sheet Sample_ID',
-                   'Sample', 'Row', 'Col', 'Blank', 'Project Plate',
-                   'Project Name', 'Compressed Plate Name', 'Well',
-                   'Plate Position', 'Primer Plate #', 'Plating',
-                   'Extraction Kit Lot', 'Extraction Robot', 'TM1000 8 Tool',
-                   'Primer Date', 'MasterMix Lot', 'Water Lot',
-                   'Processing Robot', 'Sample Plate', 'Project_Name',
-                   'Original Name', 'Plate', 'EMP Primer Plate Well', 'Name',
-                   "Illumina 5' Adapter", 'Golay Barcode',
-                   'Forward Primer Pad', 'Forward Primer Linker',
-                   '515FB Forward Primer (Parada)', 'Primer For PCR',
-                   'syndna_pool_number']
-
-        table = pd.DataFrame(columns=columns, data=data)
-        sheet = make_sample_sheet(metadata, table, 'iSeq', [1], strict=False)
+        table = pd.DataFrame(columns=self.input_columns, data=self.data)
+        sheet = make_sample_sheet(self.metadata, table, 'iSeq', [1],
+                                  strict=False)
 
         # confirm that we get a sample-sheet w/out katharoseq-control-related
         # columns.
@@ -2105,15 +2110,15 @@ class AdditionalSampleSheetCreationTests(BaseTests):
                        'Lane'}
         self.assertEqual(obs_columns, exp_columns)
 
-        ###
-
-        columns.append('Kathseq_RackID')
-        data[0].append('MyRackID')
-        table = pd.DataFrame(columns=columns, data=data)
+    def test_katharoseq_make_sample_sheet_one_optional_column_ok(self):
+        self.input_columns.append('Kathseq_RackID')
+        self.data[0].append('MyRackID')
+        table = pd.DataFrame(columns=self.input_columns, data=self.data)
 
         # sheet will be created but extended columns will not be present
         # and no error is raised. Kathseq_RackID is silently dropped.
-        sheet = make_sample_sheet(metadata, table, 'iSeq', [1], strict=False)
+        sheet = make_sample_sheet(self.metadata, table, 'iSeq', [1],
+                                  strict=False)
 
         self.assertIsNotNone(sheet)
         self.assertIsInstance(sheet, MetagenomicSampleSheetv101)
@@ -2125,16 +2130,15 @@ class AdditionalSampleSheetCreationTests(BaseTests):
                        'Lane'}
         self.assertEqual(obs_columns, exp_columns)
 
-        ###
-
+    def test_katharoseq_make_sample_sheet_one_optional_column_error(self):
         # attempt to make a sample-sheet using make_sample_sheet and w/a
         # dataset that has only one of the optional columns (Kathseq_RackID)
         # included. This should result in an error raised.
 
         # To do this, we will change the name of the sample to begin w/kath.
-        data[0][1] = 'kath.01'  # changing sample_name
+        self.data[0][1] = 'kath.01'  # changing sample_name
 
-        table = pd.DataFrame(columns=columns, data=data)
+        table = pd.DataFrame(columns=self.input_columns, data=self.data)
 
         exp = ("ErrorMessage: The TubeCode column in the Data section is "
                "missing\nErrorMessage: The katharo_description column in the "
@@ -2147,27 +2151,30 @@ class AdditionalSampleSheetCreationTests(BaseTests):
                "Message: The well_id_96 column in the Data section is missing")
 
         with self.assertRaisesRegex(ValueError, exp):
-            make_sample_sheet(metadata, table, 'iSeq', [1], strict=False)
+            make_sample_sheet(self.metadata, table, 'iSeq', [1],
+                              strict=False)
 
-        ###
-
-        # Lastly, test make_sample_sheet() w/katharoseq data.
+    def test_katharoseq_make_sample_sheet_all_optional_columns(self):
+        # test make_sample_sheet() w/katharoseq data. To do this, change the
+        # name of the sample to begin w/kath.
+        self.data[0][1] = 'kath.01'  # changing sample_name
 
         # add missing columns to the data and populate them with 'junk value'.
-        optional_columns = ['TubeCode', 'katharo_description',
-                            'number_of_cells', 'platemap_generation_date',
-                            'project_abbreviation', 'vol_extracted_elution_ul',
-                            'well_id_96']
+        optional_columns = ['Kathseq_RackID', 'TubeCode',
+                            'katharo_description', 'number_of_cells',
+                            'platemap_generation_date', 'project_abbreviation',
+                            'vol_extracted_elution_ul', 'well_id_96']
 
         for column in optional_columns:
-            columns.append(column)
-            data[0].append('junk_value')
+            self.input_columns.append(column)
+            self.data[0].append('junk_value')
 
-        table = pd.DataFrame(columns=columns, data=data)
+        table = pd.DataFrame(columns=self.input_columns, data=self.data)
 
-        sheet = make_sample_sheet(metadata, table, 'iSeq', [1], strict=False)
+        sheet = make_sample_sheet(self.metadata, table, 'iSeq', [1],
+                                  strict=False)
 
-        # confirm that a sheet was created w/all of the extended columns
+        # confirm that a sheet was created w/all the extended columns
         # required for katharoseq-controls.
         self.assertIsNotNone(sheet)
         self.assertIsInstance(sheet, MetagenomicSampleSheetv101)

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1545,7 +1545,7 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         sheet = MetatranscriptomicSampleSheetv0()
         sheet.Header['IEMFileVersion'] = 4
         sheet.Header['SheetType'] = 'standard_metag'
-        sheet.Header['SheetVersion'] = '100'
+        sheet.Header['SheetVersion'] = '0'
         sheet.Header['Investigator Name'] = 'Knight'
         sheet.Header['Experiment Name'] = 'RKO_experiment'
         sheet.Header['Date'] = '2021-08-17'


### PR DESCRIPTION
metapool can now load and validate metagenomic sample-sheets that optionally contain karathoseq controls along w/extra columns.
A new sample-sheet class for metagenomic sample-sheets has been created and will become the new current version (101). Going forward all metagenomic sample-sheets will have the optional columns functionality.
This will be extended to metatranscriptomic and abs-quant sample-sheets once everything has been reviewed, columns have been agreed upon, etc.
TODO: Add functionality to SampleSheet.add_sample() that can dynamically add columns to the data-section and perform error-handling upon the adding of the first katharoseq sample. This is for manual creation of sample-sheet objects only.

