### PR TITLE
Pin seqtk to v1.4 or above to fix spontaneous CI errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda config --add channels bioconda
-          conda create --yes -n metapool python=${{ matrix.python-version }} scikit-learn pandas numpy nose pep8 flake8 matplotlib jupyter notebook 'seaborn>=0.7.1' pip openpyxl seqtk
+          conda create --yes -n metapool python=${{ matrix.python-version }} scikit-learn pandas numpy nose pep8 flake8 matplotlib jupyter notebook 'seaborn>=0.7.1' pip openpyxl seqtk>=1.4
           conda activate metapool
           pip install coveralls flake8
           pip install -e ".[all]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda config --add channels bioconda
-          conda create --yes -n metapool python=${{ matrix.python-version }} scikit-learn pandas numpy nose pep8 flake8 matplotlib jupyter notebook 'seaborn>=0.7.1' pip openpyxl seqtk>=1.4
+          conda create --yes -n metapool python=${{ matrix.python-version }} scikit-learn pandas numpy nose pep8 flake8 matplotlib jupyter notebook 'seaborn>=0.7.1' pip openpyxl 'seqtk>=1.4'
           conda activate metapool
           pip install coveralls flake8
           pip install -e ".[all]"


### PR DESCRIPTION
CI tests that passed three weeks ago failed today, with zero changes to the code.  Tracked this to today's CI run installing a different version of seqtk (1.2) in the metapool environment, while the earlier, passing CI run installed version 1.4.  Pinned to 1.4 or above to prevent this in the future; now the tests pass again ;)