### PR TITLE
centralize functionality repeated in notebooks

### DIFF
--- a/metapool/metapool.py
+++ b/metapool/metapool.py
@@ -14,7 +14,7 @@ from .mp_strings import SAMPLE_NAME_KEY, PM_PROJECT_NAME_KEY, \
     PLATE_NAME_DELIMITER, SAMPLE_DNA_CONC_KEY, NORMALIZED_DNA_VOL_KEY, \
     SYNDNA_POOL_MASS_NG_KEY, SYNDNA_POOL_NUM_KEY, TUBECODE_KEY, \
     EXTRACTED_GDNA_CONC_KEY, PM_WELL_KEY, PM_DILUTED_KEY, \
-    get_qiita_id_from_project_name, \
+    NORMALIZED_WATER_VOL_KEY, get_qiita_id_from_project_name, \
     get_plate_num_from_plate_name, get_main_project_from_plate_name
 from .plate import _validate_well_id_96, PlateReplication
 
@@ -638,6 +638,7 @@ def calculate_norm_vol(dna_concs, ng=5, min_vol=2.5, max_vol=3500,
     sample_vols : numpy array of float
         The volumes to pool (nL)
     """
+    # mass in ng / conc in ng/uL * 1000 nL/uL = vol in nL
     sample_vols = ng / np.nan_to_num(dna_concs) * 1000
 
     sample_vols = np.clip(sample_vols, min_vol, max_vol)
@@ -645,6 +646,50 @@ def calculate_norm_vol(dna_concs, ng=5, min_vol=2.5, max_vol=3500,
     sample_vols = np.round(sample_vols / resolution) * resolution
 
     return sample_vols
+
+
+def add_vols_in_nl_to_plate_df(
+        plate_df, target_mass_ng, min_vol_in_nl, max_vol_in_nl,
+        instrument_resolution_in_nl,
+        conc_in_ng_ul_key=SAMPLE_DNA_CONC_KEY,
+        norm_sample_vol_in_nl_key=NORMALIZED_DNA_VOL_KEY,
+        norm_water_vol_in_nl_key=NORMALIZED_WATER_VOL_KEY
+):
+    """
+    Calculates nL of sample and water per well and adds to plate_df *in place*
+
+    Adds columns with names specified in norm_sample_vol_in_nl_key and
+    norm_water_vol_in_nl_key to plate_df.
+
+    Parameters
+    ----------
+    plate_df : pandas DataFrame
+        A DataFrame of plate info, containing at least the column specified in
+         conc_in_ng_ul_key
+    target_mass_ng : float
+        The desired amount of DNA mass to pool (ng)
+    max_vol_in_nl : float
+        The maximum volume that is allowable to pool (nL)
+    min_vol_in_nl : float
+        The minimum volume that is allowable to pool (nL)
+    instrument_resolution_in_nl: float
+        The resolution of the Echo instrument, in nL, which is used as a
+        rounding factor for the volumes to pool
+    conc_in_ng_ul_key : str
+        The name of column containing the sample (usually gDNA) concentrations
+    norm_sample_vol_in_nl_key : str
+        The name of column to store the calculated sample volumes
+    norm_water_vol_in_nl_key : str
+        The name of column to store the calculated water volumes
+    """
+
+    dna_vols_in_nl = calculate_norm_vol(
+        plate_df[conc_in_ng_ul_key], ng=target_mass_ng, min_vol=min_vol_in_nl,
+        max_vol=max_vol_in_nl, resolution=instrument_resolution_in_nl)
+    water_vols_in_nl = max_vol_in_nl - dna_vols_in_nl
+
+    plate_df[norm_sample_vol_in_nl_key] = dna_vols_in_nl
+    plate_df[norm_water_vol_in_nl_key] = water_vols_in_nl
 
 
 def format_dna_norm_picklist(
@@ -1843,6 +1888,40 @@ def add_undiluted_gdna_concs(a_plate_df, undiluted_gdna_conc_fp):
     return working_df
 
 
+def add_pool_input_dna_mass_ng_to_plate_df(plate_df):
+    """Calcs DNA mass to pool in ng per sample & adds to plate_df *in place*
+
+    Parameters
+    ----------
+    plate_df : pd.DataFrame
+        Plate dataframe with at least SAMPLE_DNA_CONC_KEY and
+        NORMALIZED_DNA_VOL_KEY columns.
+
+    Adds an INPUT_DNA_KEY column to plate_df, which is the mass of DNA in ng
+
+    Note that the calculated value here, which the mass of DNA (in ng)
+    *actually* put into the pooling process, is *usually* basically the
+    same as the target mass that is used upstream to calculate the
+    normalized DNA volume. That is because the normalized DNA volume is
+    *basically* calculated as target mass / concentration (so then this
+    calculation is
+    concentration * (target mass / concentration) = target mass
+    which feels a bit like a tautology). But it is not *exactly* the same
+    because (a) there is a rounding step in the normalized DNA volume
+    calculation, which introduces some difference, and more importantly
+    (b) there is a *clipping* step in the normalized DNA volume calculation,
+    which keeps the volume from being too high or too low to actually
+    physically dispense.  For samples where clipping has been applied, the
+    pooled input DNA mass calculated here can in fact be very different
+    from the target mass.
+    """
+
+    # dna conc in ng/uL * normalized dna vol in nL / 1000 nL/uL = mass in ng
+    plate_df[INPUT_DNA_KEY] = \
+        plate_df[SAMPLE_DNA_CONC_KEY] * \
+        plate_df[NORMALIZED_DNA_VOL_KEY] / 1000
+
+
 def add_syndna(plate_df, syndna_pool_number=None, syndna_concentration=None,
                syndna_percentage=5):
     """Calculates nanoliters of synDNA spike-in to add to each sample to
@@ -1851,8 +1930,7 @@ def add_syndna(plate_df, syndna_pool_number=None, syndna_concentration=None,
     Parameters
     ----------
     plate_df : pd.DataFrame
-        Growing plate dataframe with calculated gDNA input normalization values
-        including SAMPLE_DNA_CONC_KEY and NORMALIZED_DNA_VOL_KEY columns.
+        Plate dataframe with at least a INPUT_DNA_KEY column.
     syndna_pool_number : str (Default:None)
         String formatted name for synDNA pool. Typically a number.
     syndna_concentration : float (Default:None)
@@ -1862,9 +1940,9 @@ def add_syndna(plate_df, syndna_pool_number=None, syndna_concentration=None,
 
     Returns
     -------
-    plate_df : pd.DataFrame
-        returns a copy of the input pandas dataframe with INPUT_DNA_KEY,
-         SYNDNA_VOL_KEY, SYNDNA_POOL_MASS_NG_KEY columns added"""
+    result : pd.DataFrame
+        returns a copy of the input pandas dataframe with
+        SYNDNA_VOL_KEY and SYNDNA_POOL_MASS_NG_KEY columns added"""
 
     result = plate_df.copy()
     result[SYNDNA_POOL_NUM_KEY] = syndna_pool_number
@@ -1875,20 +1953,15 @@ def add_syndna(plate_df, syndna_pool_number=None, syndna_concentration=None,
         return result
 
     else:
-        if NORMALIZED_DNA_VOL_KEY not in result.columns:
+        if INPUT_DNA_KEY not in result.columns:
             raise Exception(
-                "The plate dataframe (plate_df) must have input "
-                "normalization values already calculated before "
-                "calculating synDNA addition"
+                f"The plate dataframe (plate_df) must have {INPUT_DNA_KEY} "
+                f"values already calculated before calculating synDNA addition"
             )
 
         if syndna_concentration is None:
             raise Exception("Specify the concentration of the synDNA"
                             " spike-in pool")
-
-        result[INPUT_DNA_KEY] = result[SAMPLE_DNA_CONC_KEY] * \
-            result[NORMALIZED_DNA_VOL_KEY] / 1000
-        # synDNA volume is in nL
 
         # The 1000 multiplier is to transform µL to nL because the Echo
         # dispenser uses nL as the volume unit but concentrations are

--- a/metapool/mp_strings.py
+++ b/metapool/mp_strings.py
@@ -53,6 +53,7 @@ SYNDNA_POOL_NUM_KEY = "syndna_pool_number"
 SAMPLE_DNA_CONC_KEY = "Sample DNA Concentration"
 MINIPICO_LIB_CONC_KEY = 'MiniPico Library Concentration'
 NORMALIZED_DNA_VOL_KEY = "Normalized DNA volume"
+NORMALIZED_WATER_VOL_KEY = 'Normalized water volume'
 TELLSEQ_BARCODE_ID_KEY = "barcode_id"
 TELLSEQ_BARCODE_SET_ID_KEY = "barcode_set_id"
 SYNDNA_POOL_MASS_NG_KEY = "mass_syndna_input_ng"

--- a/metapool/tests/test_metapool.py
+++ b/metapool/tests/test_metapool.py
@@ -6,7 +6,8 @@ import os
 from io import StringIO
 from pandas.testing import assert_frame_equal
 from metapool.metapool import (read_plate_map_csv, read_pico_csv,
-                               calculate_norm_vol, format_dna_norm_picklist,
+                               calculate_norm_vol, add_vols_in_nl_to_plate_df,
+                               format_dna_norm_picklist,
                                format_index_picklist,
                                compute_qpcr_concentration,
                                compute_shotgun_pooling_values_eqvol,
@@ -31,9 +32,11 @@ from metapool.metapool import (read_plate_map_csv, read_pico_csv,
                                generate_override_cycles_value, TUBECODE_KEY,
                                is_absquant, add_undiluted_gdna_concs,
                                _read_and_label_pico_csv, load_concentrations,
-                               select_sample_dilutions)
+                               select_sample_dilutions,
+                               add_pool_input_dna_mass_ng_to_plate_df)
 from metapool.mp_strings import SYNDNA_POOL_NUM_KEY, EXTRACTED_GDNA_CONC_KEY, \
-    PM_PROJECT_PLATE_KEY, PM_COMPRESSED_PLATE_NAME_KEY
+    PM_PROJECT_PLATE_KEY, PM_COMPRESSED_PLATE_NAME_KEY, SAMPLE_DNA_CONC_KEY, \
+    NORMALIZED_DNA_VOL_KEY, NORMALIZED_WATER_VOL_KEY
 from xml.etree.ElementTree import ParseError
 
 
@@ -787,6 +790,24 @@ class Tests(TestCase):
         obs_vols = calculate_norm_vol(dna_concs)
 
         np.testing.assert_allclose(exp_vols, obs_vols)
+
+    def test_add_vols_in_nl_to_plate_df(self):
+        """ Test that function adds correct columns in place to the input df"""
+        working_df = pd.DataFrame({
+            'sample_name': ["Abe", "Bob", "Cat", "Dan"],
+            SAMPLE_DNA_CONC_KEY: [2, 7.89, np.nan, .0]})
+
+        add_vols_in_nl_to_plate_df(
+            working_df, target_mass_ng=5, min_vol_in_nl=2.5,
+            max_vol_in_nl=3500, instrument_resolution_in_nl=2.5)
+
+        exp_df = pd.DataFrame({
+            'sample_name': ["Abe", "Bob", "Cat", "Dan"],
+            SAMPLE_DNA_CONC_KEY: [2, 7.89, np.nan, .0],
+            NORMALIZED_DNA_VOL_KEY: [2500., 632.5, 3500., 3500.],
+            NORMALIZED_WATER_VOL_KEY: [1000, 2867.5, 0., .0]})
+
+        pd.testing.assert_frame_equal(exp_df, working_df)
 
     def test_format_dna_norm_picklist(self):
 
@@ -1638,6 +1659,38 @@ class Tests(TestCase):
             input_plate_df, input_pico_fp)
         assert_frame_equal(exp_plate_df, obs_plate_df)
 
+    def test_add_pool_input_dna_mass_ng_to_plate_df(self):
+        """ Test function adds correct Input DNA column in place to input df"""
+
+        # construct an example DataFrame
+        test_df = pd.DataFrame({'Sample': ['sample_1', 'sample_2',
+                                           'sample_3', 'sample_4',
+                                           'sample5'],
+                                'Sample DNA Concentration': [20, 10, 5, 1,
+                                                             0.5],
+                                'Normalized DNA volume': [250.0, 500.0,
+                                                          1000.0, 3500.0,
+                                                          3500.0],
+                                'Ignored column': [50.0, 0.0, 20.0, 0.0, 0.0]
+                                })
+
+        # expected results
+        exp_plate_df = pd.DataFrame({'Sample': ['sample_1', 'sample_2',
+                                                'sample_3', 'sample_4',
+                                                'sample5'],
+                                     'Sample DNA Concentration': [20, 10, 5, 1,
+                                                                  0.5],
+                                     'Normalized DNA volume': [250.0, 500.0,
+                                                               1000.0, 3500.0,
+                                                               3500.0],
+                                     'Ignored column':
+                                         [50.0, 0.0, 20.0, 0.0, 0.0],
+                                     'Input DNA': [5.0, 5.0, 5.0, 3.50, 1.75]
+                                     })
+
+        add_pool_input_dna_mass_ng_to_plate_df(test_df)
+        pd.testing.assert_frame_equal(exp_plate_df, test_df)
+
     def test_add_syndna_no_spikein(self):
         # tests running the add_syndna() function
         # with default arguments, which should just
@@ -1691,13 +1744,7 @@ class Tests(TestCase):
                                            'sample_3', 'sample_4',
                                            'sample5'],
                                 'Well': ['A1', 'B1', 'C1', 'D1', 'E1'],
-                                'Sample DNA Concentration': [20, 10, 5, 1,
-                                                             0.5],
-                                'Normalized DNA volume': [250.0, 500.0,
-                                                          1000.0, 3500.0,
-                                                          3500.0],
-                                'Normalized water volume': [3250.0, 3000.0,
-                                                            2500.0, 0.0, 0.0],
+                                'Input DNA': [5.0, 5.0, 5.0, 3.50, 1.75],
                                 'Diluted': [False, False, False, False, False]
                                 })
 
@@ -1708,15 +1755,6 @@ class Tests(TestCase):
                                                 'sample_3', 'sample_4',
                                                 'sample5'],
                                      'Well': ['A1', 'B1', 'C1', 'D1', 'E1'],
-                                     'Sample DNA Concentration': [20, 10, 5, 1,
-                                                                  0.5],
-                                     'Normalized DNA volume': [250.0, 500.0,
-                                                               1000.0, 3500.0,
-                                                               3500.0],
-                                     'Normalized water volume': [3250.0,
-                                                                 3000.0,
-                                                                 2500.0,
-                                                                 0.0, 0.0],
                                      'Diluted': [False, False, False, False,
                                                  False],
                                      'syndna_pool_number': ['pool1', 'pool1',
@@ -1734,9 +1772,27 @@ class Tests(TestCase):
                                       check_like=True,
                                       rtol=1e-3)
 
-    def test_add_syndna_pool1_noconcentration_exc(self):
+    def test_add_syndna_pool1_err_noconcentration(self):
         # testing a raised exception when user forgets to input
         # synDNA pool concentration
+
+        # construct an example DataFrame
+        test_df = pd.DataFrame({'Sample': ['sample_1', 'sample_2',
+                                           'sample_3', 'sample_4',
+                                           'sample5'],
+                                'Well': ['A1', 'B1', 'C1', 'D1', 'E1'],
+                                'Input DNA': [5.0, 5.0, 5.0, 3.50, 1.75],
+                                'Diluted': [False, False, False, False, False]
+                                })
+
+        partial_err_msg = "Specify the concentration of the synDNA"
+        with self.assertRaisesRegex(Exception, partial_err_msg):
+            add_syndna(test_df, syndna_pool_number='pool1',
+                       syndna_concentration=None)
+
+    def test_add_syndna_pool1_err_no_input_dna(self):
+        # testing a raised exception when user forgets to provide
+        # Input DNA column
 
         # construct an example DataFrame
         test_df = pd.DataFrame({'Sample': ['sample_1', 'sample_2',
@@ -1753,9 +1809,11 @@ class Tests(TestCase):
                                 'Diluted': [False, False, False, False, False]
                                 })
 
-        with self.assertRaises(Exception):
+        partial_err_msg = \
+            r"The plate dataframe \(plate_df\) must have Input DNA"
+        with self.assertRaisesRegex(Exception, partial_err_msg):
             add_syndna(test_df, syndna_pool_number='pool1',
-                       syndna_concentration=None)
+                       syndna_concentration=2.22)
 
     def test_generate_override_cycles_value(self):
         for fp, exp, adapter_length in self.runinfos:


### PR DESCRIPTION
I discovered this week that, in addition to repeating the code to calculate DNA and water volumes across workflows, the current matrix tube and tellseq notebooks repeat the calculation of "Input DNA" *within* a workflow if you are using synDNA. We are fortunate that that calculation was in fact being done the same way both times, but it is a bug waiting to happen.

This PR creates two new methods in the metapool module that (a) calculate dna and water volumes and add to a plate_df, and (b) calculate Input DNA and add it to a plate_df.  Finally, it *removes* the calculation of Input DNA from `add_syndna`, now requiring that it be done before that call; this will be consistent with the fact that, later, we need the Input DNA column even if we aren't using syndna.

This PR does NOT make use of these new functions yet!  I am trying to keep this bite-sized and self-contained.  The next step (which I already have tee-d up) is to modify the matrix tube and tellseq notebooks to USE these new functions, but that is not part of this PR.