### PR TITLE
fix lack of contains_replicates definition in metat v10 sample sheet

### DIFF
--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -1620,6 +1620,11 @@ class MetatranscriptomicSampleSheetv10(KLSampleSheet):
                      'total_rna_concentration_ng_ul',
                      ELUTION_VOL_KEY, 'Well_description')
 
+    _KL_ADDTL_DF_SECTIONS = MappingProxyType({
+        _BIOINFORMATICS_KEY: _BIOINFORMATICS_COLS_W_REP_SUPPORT,
+        _CONTACT_KEY: _CONTACT_COLS,
+    })
+
     _CARRIED_PREP_COLUMNS = _BASE_CARRIED_PREP_COLUMNS + (
                             'total_rna_concentration_ng_ul',
                             ELUTION_VOL_KEY)

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -2313,6 +2313,11 @@ class AdditionalSampleSheetCreationTests(BaseTests):
         sheet = MetatranscriptomicSampleSheetv10(metat_fp)
         self.assertTrue(sheet.validate_and_scrub_sample_sheet())
 
+        # Metat v10 should include (and correctly parse) contains_replicates
+        self.assertTrue(
+            CONTAINS_REPLICATES_KEY in sheet.Bioinformatics.columns)
+        self.assertFalse(sheet.Bioinformatics[CONTAINS_REPLICATES_KEY].all())
+
         # confirm load_sample_sheet() returns the correct child class of
         # KLSampleSheet.
         sheet = load_sample_sheet(metat_fp)


### PR DESCRIPTION
Fix issue identified for NPH metat sample sheet where sheet was being processed as though it contained replicates when in fact it did not. Issue was traced to `sheet_needs_demuxing` returning "FALSE" instead of `False`, which turned out to be due to `MetatranscriptomicSampleSheetv10` not defining `contains_replicates` as one of its known columns (and therefore not normalizing its values).

To fix, added an explicit definition of the `_KL_ADDTL_DF_SECTIONS`, including the Bioinformatics and Contacts sections, as is done in other sheet types. Also extended the metat v10 sheet load test so that it failed (due to bad `contains_replicates` value)  before this fix and passes after it.