### PR TITLE
Change the default OverrideCycles in a sample sheet 

### DIFF
--- a/metapool/sample_sheet.py
+++ b/metapool/sample_sheet.py
@@ -155,7 +155,7 @@ class KLSampleSheet(sample_sheet.SampleSheet):
     _SETTINGS = MappingProxyType({
         'ReverseComplement': '0',
         'MaskShortReads': '1',
-        'OverrideCycles': 'Y151;I8N2;I8N2;Y151'
+        'OverrideCycles': 'Y151;I8N2;N16I8;Y151'
     })
 
     _ALL_METADATA = MappingProxyType({

--- a/metapool/tests/test_sample_sheet.py
+++ b/metapool/tests/test_sample_sheet.py
@@ -1461,7 +1461,7 @@ class SampleSheetWorkflow(BaseTests):
         settings = {
             'ReverseComplement': '0',
             'MaskShortReads': '1',
-            'OverrideCycles': 'Y151;I8N2;I8N2;Y151'
+            'OverrideCycles': 'Y151;I8N2;N16I8;Y151'
         }
         self.assertEqual(obs.Settings, settings)
 
@@ -1509,7 +1509,7 @@ class SampleSheetWorkflow(BaseTests):
         self.assertDictEqual(dict(obs.Settings),
                              {'ReverseComplement': '0',
                               'MaskShortReads': '1',
-                              'OverrideCycles': 'Y151;I8N2;I8N2;Y151'})
+                              'OverrideCycles': 'Y151;I8N2;N16I8;Y151'})
 
         pd.testing.assert_frame_equal(obs.Bioinformatics, exp_bfx)
         pd.testing.assert_frame_equal(obs.Contact, exp_contact)


### PR DESCRIPTION
The wet lab complained that the default value is wrong (and apparently the I and N are in the wrong order) so changed to a value that works for (at least some) current metag and metat runs.  Won't affect amplicon runs bc OverrideCycles is deleted from them.  

To be clear, I don't expect that this is the right OverrideCycles value for every run--after a sequencing run is performed, someone will still need to take the override cycles info provided by the sequencing core and ensure that it matches what is in the run's sample sheet, or else correct it manually.  However, having the default in the wrong order appears to be confusing folks who do the manual correction and contributing to incorrect correction.