### PR TITLE
strip leading/trailing whitespace from sample accession values

### DIFF
--- a/metapool/metapool.py
+++ b/metapool/metapool.py
@@ -2625,8 +2625,8 @@ def validate_plate_df(plate_df, metadata, sample_accession_df, blanks_dir,
     duplicated_samples = plate_df.Sample[plate_df.Sample.duplicated()]
     if len(duplicated_samples):
         raise ValueError(
-            "The following sample names are duplicated %s"
-            % ", ".join(sorted(duplicated_samples))
+            "The following sample names are duplicated: '%s'"
+            % "', '".join(sorted(duplicated_samples))
         )
 
 

--- a/metapool/metapool.py
+++ b/metapool/metapool.py
@@ -2140,6 +2140,10 @@ def compress_plates(compression_layout, sample_accession_df,
         compressed_plate_df = pd.concat([compressed_plate_df, plate_map])
     # next plate index in compression layout dict
 
+    # strip leading and/or trailing whitespace from all columns
+    sample_accession_df = sample_accession_df.map(
+        lambda x: x.strip() if isinstance(x, str) else x)
+    # if we are not preserving leading zeroes, strip those too
     if not preserve_leading_zeroes:
         sample_accession_df = \
             strip_tubecode_leading_zeroes(sample_accession_df)
@@ -2540,9 +2544,9 @@ def validate_plate_df(plate_df, metadata, sample_accession_df, blanks_dir,
     if missing_samples.empty:
         warnings.warn("All samples have associated metadata :D")
     else:
-        missing_str = ", ".join(missing_samples.astype(str))
+        missing_str = "', '".join(missing_samples.astype(str))
         warning_message = ("The following samples are missing metadata: "
-                           f"{missing_str}")
+                           f"'{missing_str}'")
         raise ValueError(warning_message)
 
     # This checks that all the tubes in our plate_df files are indeed

--- a/metapool/tests/test_metapool.py
+++ b/metapool/tests/test_metapool.py
@@ -322,8 +322,12 @@ class Tests(TestCase):
              'Plate elution volume': 70}
         ]
 
-        plate_df_obs = compress_plates(compression, self.sa_augmented_df,
-                                       well_col='Well')
+        sa_df = self.sa_augmented_df.copy()
+        # add leading and trailing space to every field of sa_df,
+        # so we can check if the code strips them correctly
+        sa_df = sa_df.map(lambda x: f" {x} " if isinstance(x, str) else x)
+
+        plate_df_obs = compress_plates(compression, sa_df, well_col='Well')
         plate_df_exp = pd.read_csv(self.comp_plate_multi_proj_on_plate_exp_fp,
                                    dtype={TUBECODE_KEY: str}, sep='\t')
 
@@ -497,7 +501,7 @@ class Tests(TestCase):
                                                '0000000000'),
                               self.metadata, self.sa_df,
                               self.blanks_dir)
-        # Raisees error for duplicate sample 41B.Month6.10
+        # Raises error for duplicate sample 41B.Month6.10
         with self.assertRaises(ValueError):
             validate_plate_df(plate_df.replace('41B.Month6.1',
                                                '41B.Month6.10'),


### PR DESCRIPTION
The wet lab experienced an issue where their input sample accession file had trailing whitespaces in the sample names.  While the existing code will (correctly) throw an error in this case (although I still beefed up the error message a bit), it seems better to just strip the sample accession input prophylactically so they don't have to go back and fix errors manually.