### PR TITLE
refactor to best expose functionality needed by qp-klp

### DIFF
--- a/metapool/__init__.py
+++ b/metapool/__init__.py
@@ -29,7 +29,7 @@ from .controls import is_blank
 from .metapool import (extract_stats_metadata, sum_lanes, compress_plates,
                        add_controls, generate_override_cycles_value,
                        strip_tubecode_leading_zeroes)
-from .sequencers import get_model_by_machine_prefix
+from .sequencers import get_model_by_instrument_id
 
 
 __credits__ = ("https://github.com/biocore/kl-metapool/"
@@ -59,7 +59,7 @@ __all__ = ['IGMManifest', 'add_controls', 'assign_emp_index', 'autopool',
            'SYNDNA_POOL_NUM_KEY', 'SAMPLE_DNA_CONC_KEY',
            'NORMALIZED_DNA_VOL_KEY',
            'SYNDNA_POOL_MASS_NG_KEY', 'ELUTION_VOL_KEY',
-           'EXTRACTED_GDNA_CONC_KEY', 'get_model_by_machine_prefix']
+           'EXTRACTED_GDNA_CONC_KEY', 'get_model_by_instrument_id']
 
 from . import _version
 

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -141,59 +141,20 @@ def _get_machine_code(instrument_model):
         If the instrument model is malformed and does not contain a valid
         machine code.
     """
-    # the machine code represents the first 1 to 2 letters of the
-    # instrument model
-    machine_code = re.compile(r'^([a-zA-Z]{1,2})')
-    matches = re.search(machine_code, instrument_model)
-    if matches is None:
-        raise ValueError('Cannot find a machine code. This instrument '
-                         'model is malformed %s. The machine code is a '
-                         'one or two character prefix.' % instrument_model)
-    return matches[0]
+    # the machine code is everything before the first number
+    # (we expect these to be letters, so pattern could be improved ...)
+    matches = re.match(r"^(.*?)\d.*", instrument_model)
+
+    if matches is not None:
+        machine_code = matches.group(1)
+        if machine_code != "":
+            return machine_code
+
+    raise ValueError(f"Cannot find a machine code; the instrument "
+                     f"model '{instrument_model}' is malformed.")
 
 
-def get_model_and_center(instrument_code):
-    """Determine instrument model and center using instrument code.
-
-    Parameters
-    ----------
-    instrument_code: str
-        Instrument code from a run identifier.
-
-    Returns
-    -------
-    str
-        Instrument model.
-    str
-        Run center associated with the instrument.
-
-    Raises
-    ------
-    ValueError
-        If zero or more than one machine prefixes are associated with
-        the instrument code.
-    """
-
-    run_center = _LAB_RUN_CENTER  # Default run center for lab data
-    available_sequencer_types = _load_sequencer_types()
-
-    instrument_id = instrument_code.split('_')[0]
-    if instrument_id in _INSTRUMENT_LOOKUP.index:
-        run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
-        inst_model_type = _INSTRUMENT_LOOKUP.loc[
-            instrument_id, _MODEL_TYPE_KEY]
-        instrument_model = _get_model_by_sequencer_type_name(
-            inst_model_type, sequencer_types=available_sequencer_types)
-    else:
-        instrument_prefix = _get_machine_code(instrument_id)
-        instrument_model = get_model_by_machine_prefix(
-            instrument_prefix, sequencer_types=available_sequencer_types)
-    # end if instrument_id is in the lookup or if must look up by prefix
-
-    return instrument_model, run_center
-
-
-def get_model_by_machine_prefix(instrument_prefix, sequencer_types=None):
+def _get_model_by_machine_prefix(instrument_prefix, sequencer_types=None):
     """Get the instrument model by its machine prefix.
 
     Parameters
@@ -232,6 +193,65 @@ def get_model_by_machine_prefix(instrument_prefix, sequencer_types=None):
     instrument_model = _get_model_by_sequencer_type_name(
         inst_model_type, sequencer_types=models_w_prefix)
     return instrument_model
+
+
+def get_model_by_instrument_id(instrument_id, sequencer_types=None):
+    """
+
+    Parameters
+    ----------
+    instrument_id
+    sequencer_types
+
+    Returns
+    -------
+
+    """
+    sequencer_types = _load_sequencer_types(existing_types=sequencer_types)
+    instrument_prefix = _get_machine_code(instrument_id)
+    instrument_model = _get_model_by_machine_prefix(
+        instrument_prefix, sequencer_types=sequencer_types)
+    return instrument_model
+
+
+def get_model_and_center(instrument_code):
+    """Determine instrument model and center using instrument code.
+
+    Parameters
+    ----------
+    instrument_code: str
+        Instrument code from a run identifier.
+
+    Returns
+    -------
+    str
+        Instrument model.
+    str
+        Run center associated with the instrument.
+
+    Raises
+    ------
+    ValueError
+        If zero or more than one machine prefixes are associated with
+        the instrument code.
+    """
+
+    run_center = _LAB_RUN_CENTER  # Default run center for lab data
+    available_sequencer_types = _load_sequencer_types()
+
+    instrument_id = instrument_code.split('_')[0]
+    if instrument_id in _INSTRUMENT_LOOKUP.index:
+        run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
+        inst_model_type = _INSTRUMENT_LOOKUP.loc[
+            instrument_id, _MODEL_TYPE_KEY]
+        instrument_model = _get_model_by_sequencer_type_name(
+            inst_model_type, sequencer_types=available_sequencer_types)
+    else:
+        instrument_model = get_model_by_instrument_id(
+            instrument_id, sequencer_types=available_sequencer_types)
+    # end if instrument_id is in the lookup or if must look up by prefix
+
+    return instrument_model, run_center
 
 
 def _get_model_by_sequencer_type_name(inst_model_type, sequencer_types):

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -1,7 +1,7 @@
 from metapool.sequencers import _deep_freeze, _get_machine_code, \
     get_model_and_center, get_sequencers_w_key_value, get_sequencer_type, \
     get_i5_index_sequencers, is_i5_revcomp_sequencer, \
-    get_model_by_machine_prefix
+    get_model_by_instrument_id
 from types import MappingProxyType
 from unittest import TestCase, main
 
@@ -18,25 +18,23 @@ class TestSequencers(TestCase):
         self.assertEqual(obs, 'MN')
 
     def test__get_machine_code_err(self):
-        with self.assertRaisesRegex(ValueError,
-                                    'Cannot find a machine code. This '
-                                    'instrument model is malformed 8675309. '
-                                    'The machine code is a one or two '
-                                    'character prefix.'):
+        err = ("Cannot find a machine code; the instrument model "
+               "'8675309' is malformed.")
+        with self.assertRaisesRegex(ValueError, err):
             _get_machine_code('8675309')
 
-    def test_get_model_by_machine_prefix(self):
+    def test_get_model_by_instrument_id(self):
         """Test getting model by machine prefix."""
-        obs = get_model_by_machine_prefix('MN')
+        obs = get_model_by_instrument_id('MN00178')
         self.assertEqual(obs, 'Illumina MiniSeq')
 
-    def test_get_model_by_machine_prefix_err_none(self):
+    def test_get_model_by_instrument_id_err_none(self):
         """Test error when no model found for machine prefix."""
-        err = "Unrecognized machine_prefix 'MQ'."
+        err = "Cannot find a machine code"
         with self.assertRaisesRegex(ValueError, err):
-            get_model_by_machine_prefix('MQ')
+            get_model_by_instrument_id('MQ')
 
-    def test_get_model_by_machine_prefix_err_multiple(self):
+    def test_get_model_by_instrument_id_err_multiple(self):
         external_mapping = _deep_freeze({
             "MiniSeq": {
                 'machine_prefix': 'MN',
@@ -55,8 +53,8 @@ class TestSequencers(TestCase):
         err = ("Found 2 sequencer types with machine_prefix 'LH': "
                "NovaSeqX, NovaSeqXPlus.")
         with self.assertRaisesRegex(ValueError, err):
-            get_model_by_machine_prefix(
-                'LH', sequencer_types=external_mapping)
+            get_model_by_instrument_id(
+                'LH1118920', sequencer_types=external_mapping)
 
     def test_get_model_and_center_by_model_prefix(self):
         obs = get_model_and_center('D32611_0365_G00DHB5YXX')

--- a/sequencer_types.yml
+++ b/sequencer_types.yml
@@ -66,3 +66,8 @@ NovaSeqXPlus:
     model_name: 'Illumina NovaSeq X Plus'
     # See above comment for NovaSeqX re: revcomp_samplesheet_i5_index
     revcomp_samplesheet_i5_index: false
+# NB: InstrumentUtils class in qp-klp used to define
+# an 'SN': 'RapidRun' machine prefix, but as of 20250703,
+# we don't seem to have any data with that prefix.  The
+# qp-klp comments say RapidRun was HiSeq 2500 (?) which is
+# confusing, so not adding it here until/unless we need it.


### PR DESCRIPTION
Turns out that what qp-klp mostly needs to do is look up model names by instrument ids, which was functionality already implemented within `_get_model_and_center`, so I broke it out into its own public function and made it accessible for import directly from metapool via the `__init__`.