### PR TITLE
Fixes for the amplicon notebook (#317)

### DIFF
--- a/metapool/mp_strings.py
+++ b/metapool/mp_strings.py
@@ -31,6 +31,7 @@ PROJECT_FULL_NAME_KEY = "full_project_name"
 # NB: don't use this as the name for a column of sample identifiers.  It is
 # the key for a list of sample details *objects* (e.g., dictionaries)
 SAMPLES_DETAILS_KEY = "samples"
+CONTROLS_DESCRIPTION_KEY = "description"
 
 # Plate map (PM) column names
 PM_SAMPLE_KEY = "Sample"

--- a/metapool/prep.py
+++ b/metapool/prep.py
@@ -735,13 +735,14 @@ def generate_qiita_prep_file(platedf, seqtype):
     # although some columns should be allowed to pass through, there are some
     # columns currently passed into metapool through the pre-prep file that
     # should definitely _not_ appear in the output. These include the
-    # following:
+    # following; note that 'description' is a reserved column name for Qiita
+    # sample info, which is why it cannot be used in the prep file.
     remove_these = {'Blank', 'Col', 'Compressed Plate Name', 'Plate Position',
                     'EMP Primer Plate Well', 'Forward Primer Pad', 'Name',
                     'Illumina 5prime Adapter', 'Original Name', 'Plate', 'Row',
                     'Primer For PCR', 'Project Plate', 'index',
                     'Plate elution volume', 'Plate map file', 'Time',
-                    'RackID'}
+                    'RackID', 'description'}
 
     # only remove the columns from the above set that are actually present in
     # the prep dataframe to avoid possible errors.

--- a/metapool/tests/test_prep.py
+++ b/metapool/tests/test_prep.py
@@ -16,6 +16,7 @@ from metapool.prep import (preparations_for_run, remove_qiita_id,
                            preparations_for_run_mapping_file, demux_pre_prep,
                            pre_prep_needs_demuxing,
                            _map_files_to_sample_ids, _find_filtered_files)
+from metapool.mp_strings import CONTROLS_DESCRIPTION_KEY
 
 
 class TestPrep(TestCase):
@@ -480,7 +481,7 @@ class TestPrep(TestCase):
             "TubeCode",
             "Kathseq_RackID",
             "number_of_cells",
-            "description",
+            CONTROLS_DESCRIPTION_KEY,
             ]
 
         data = [
@@ -668,7 +669,8 @@ class TestPrep(TestCase):
             "Forward Primer Linker",
             "515FB Forward Primer (Parada)",
             "Primer For PCR",
-            "sample sheet Sample_ID",]
+            "sample sheet Sample_ID",
+            "description",]
         columns2 = [
             "Sample",
             "Row",
@@ -766,7 +768,8 @@ class TestPrep(TestCase):
                     "AATGATACGGCGACCACCGAGATCTACACGCTAGCCTTCGTCGCT"
                     "ATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
                 ),
-                "X00180471",],
+                "X00180471",
+                ""],
             [
                 "X00180199",
                 "C",
@@ -800,7 +803,8 @@ class TestPrep(TestCase):
                     "AATGATACGGCGACCACCGAGATCTACACGCTCGTATAAATGCG"
                     "TATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
                 ),
-                "X00180199",],
+                "X00180199",
+                "positive control",],
             ]
 
         data2 = [

--- a/metapool/tests/test_util.py
+++ b/metapool/tests/test_util.py
@@ -5,7 +5,7 @@ import os
 from unittest import TestCase
 from metapool.util import join_dfs_from_files, \
     extend_sample_accession_df, extend_compression_layout_info, \
-    _check_for_missing_df_ids
+    _check_for_missing_df_ids, drop_unnamed_nan_columns
 
 
 class NotebookSupportTests(TestCase):
@@ -359,3 +359,25 @@ class NotebookSupportTests(TestCase):
                             "compression layout is not in the studies info"):
             extend_compression_layout_info(self.compress_layout,
                                            incomplete_studies_info)
+
+    def test_drop_unnamed_nan_columns(self):
+        """Test dropping columns iff named 'Unnamed:' and values all NaN."""
+        df = pandas.DataFrame({
+            'Unnamed: A': [None, None, None],
+            'Unnamed: B': [None, None, None],
+            'Unnamed: 0': [1, 2, 3],
+            'Unnamed: 1': [None, None, None],
+            'col1': [4, 5, 6],
+            'Unnamed: 2': [None, None, None],
+            'col2': [None, None, None],
+            'Unnamed: 3': [None, None, None]
+        })
+
+        expected_df = pandas.DataFrame({
+            'Unnamed: 0': [1, 2, 3],
+            'col1': [4, 5, 6],
+            'col2': [None, None, None]
+        })
+
+        result_df = drop_unnamed_nan_columns(df)
+        assert_frame_equal(result_df, expected_df)

--- a/metapool/util.py
+++ b/metapool/util.py
@@ -172,3 +172,15 @@ def get_set_fp(set_fbase, set_id, extension="txt"):
 def warn_if_fp_exists(fp):
     if os.path.isfile(fp):
         warnings.warn(f"Warning! This file exists already: {fp}.")
+
+
+def drop_unnamed_nan_columns(df):
+    """
+    Drops columns whose names start with 'Unnamed:' and contain only NaN values
+    """
+    return df.drop(
+        columns=[
+            col for col in df.columns
+            if col.startswith('Unnamed:') and df[col].isna().all()
+        ]
+    )

--- a/notebooks/amplicon_pre_prep_file_generator.ipynb
+++ b/notebooks/amplicon_pre_prep_file_generator.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "sample_accession_fp = './test_data/Plate_Maps/2022_summer_Celeste_Adaptation_16_17_18_21_sa_file.tsv'\n",
     "if not os.path.isfile(sample_accession_fp):\n",
-    "    print(\"Problem! %s is not a path to a valid file\" % file)\n",
+    "    print(\"Problem! %s is not a path to a valid file\" % sample_accession_fp)\n",
     "\n",
     "sample_accession_df = pd.read_csv(sample_accession_fp,dtype={'TubeCode':str,\n",
     "                                                            'sample_name':str},\n",
@@ -103,8 +103,8 @@
    "outputs": [],
    "source": [
     "metadata_fp = './test_data/Plate_Maps/12986_20230314-090655.txt'\n",
-    "if not os.path.isfile(sample_accession_fp):\n",
-    "    print(\"Problem! %s is not a path to a valid file\" % file)\n",
+    "if not os.path.isfile(metadata_fp):\n",
+    "    print(\"Problem! %s is not a path to a valid file\" % metadata_fp)\n",
     "\n",
     "metadata = pd.read_csv(metadata_fp, sep='\\t')\n",
     "\n",


### PR DESCRIPTION
* fix copy-paste bugs in handling missing files

* make const for control descriptions col name

* remove 'description' column when making qiita pre-prep file

* strip "Unnamed" all-nan columns from visionmate plate map dfs

* lint